### PR TITLE
WIP: Disable more unsafe casting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tapir"
 uuid = "07d77754-e150-4737-8c94-cd238a1fb45b"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.2.15"
+version = "0.2.16"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -89,8 +89,8 @@ end
 
 @intrinsic bitcast
 function rrule!!(f::CoDual{typeof(bitcast)}, t::CoDual{Type{T}}, x::CoDual{V}) where {T, V}
-    if T <: IEEEFloat || V <: IEEEFloat
-        msg = "It is not permissible to bitcast to or from a differentiable type during " *
+    if T <: IEEEFloat
+        msg = "It is not permissible to bitcast to a differentiable type during " *
         "AD, as this risks dropping tangents, and therefore risks silently giving the " *
         " wrong answer. If this call to bitcast appears as part of the implementation of " *
         "a differentiable function, you should write a rule for this function, or modify " *

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -24,10 +24,30 @@
 
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:builtins))
 
-    @testset "Disable bitcast to differentiable type" begin
+    @testset "Disable casting to / from floats inside AD" begin
         @test_throws(
             ArgumentError,
             rrule!!(zero_fcodual(bitcast), zero_fcodual(Float64), zero_fcodual(5))
+        )
+        @test_throws(
+            ArgumentError,
+            rrule!!(zero_fcodual(bitcast), zero_fcodual(UInt64), zero_fcodual(5.0))
+        )
+        @test_throws(
+            ArgumentError,
+            rrule!!(
+                zero_fcodual(Tapir.IntrinsicsWrappers.fptosi),
+                zero_fcodual(Int),
+                zero_fcodual(1.0),
+            ),
+        )
+        @test_throws(
+            ArgumentError,
+            rrule!!(
+                zero_fcodual(Tapir.IntrinsicsWrappers.fptoui),
+                zero_fcodual(UInt),
+                zero_fcodual(1.0),
+            ),
         )
     end
 end

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -31,10 +31,6 @@
         )
         @test_throws(
             ArgumentError,
-            rrule!!(zero_fcodual(bitcast), zero_fcodual(UInt64), zero_fcodual(5.0))
-        )
-        @test_throws(
-            ArgumentError,
             rrule!!(
                 zero_fcodual(Tapir.IntrinsicsWrappers.fptosi),
                 zero_fcodual(Int),


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Tapir.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

I discovered more ways that casting can cause problems in seemingly innocuous code. In particular, if you ask Tapir to differentiate
```julia
function h(p)
    a = [1,2,3,4,5]
    buf_view = view(a,3:4)
    buf_view[1] = p
    return a[3]*2.0
end
```
at `p = 2.0`, the answer is currently zero. I was amazed that this works at all until I realised that Julia will convert `p` to an `Int` when it tries to write it to `buf_view` if it's the case that `p` happens to be integer valued. If this happens, gradients get dropped and the wrong answer is given.

As part of this PR, I went back over the intrinsics involved in casting to check if there are any more, and I don't believe there are any more which risk causing problems -- hopefully that will prove to be the case.

edit: I've converted this to a WIP because it's going to take a little bit of time to figure out what's going on in all of the cases where `fptosi` and `fptoui` are used in actually innocuous code that doesn't result in dropped gradient info. For the most part, it's just going to be declaring things non-differentiable, but there might be a couple of tricky cases.

This may also motivate a more general approach to this in which we have a macro / trait which can be applied to methods of functions which asserts that it's fine to "drop" gradients for all code inside the method, as we're confident that it's not doing it in a way which risks giving the wrong answer, but that they should otherwise be differentiated as usual. Writing the macro / trait / whatever winds up being a convenient approach to this ought really to be straightforward.