### PR TITLE
Remove Method of zero_like_rdata_from_type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.7"
+version = "0.4.8"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/zero_like_rdata.jl
+++ b/src/interpreter/zero_like_rdata.jl
@@ -24,8 +24,6 @@ function zero_like_rdata_type(::Type{P}) where {P}
     return can_produce_zero_rdata_from_type(P) ? R : Union{R, ZeroRData}
 end
 
-# zero_like_rdata_type(::TypeVar) = NoRData
-
 """
     zero_like_rdata_from_type(::Type{P}) where {P}
 
@@ -37,5 +35,3 @@ It is always valid to return a `ZeroRData`,
 function zero_like_rdata_from_type(::Type{P}) where {P}
     return can_produce_zero_rdata_from_type(P) ? zero_rdata_from_type(P) : ZeroRData()
 end
-
-# zero_like_rdata_from_type(::TypeVar) = NoRData()

--- a/src/interpreter/zero_like_rdata.jl
+++ b/src/interpreter/zero_like_rdata.jl
@@ -38,4 +38,4 @@ function zero_like_rdata_from_type(::Type{P}) where {P}
     return can_produce_zero_rdata_from_type(P) ? zero_rdata_from_type(P) : ZeroRData()
 end
 
-zero_like_rdata_from_type(::TypeVar) = NoRData()
+# zero_like_rdata_from_type(::TypeVar) = NoRData()

--- a/src/interpreter/zero_like_rdata.jl
+++ b/src/interpreter/zero_like_rdata.jl
@@ -24,7 +24,7 @@ function zero_like_rdata_type(::Type{P}) where {P}
     return can_produce_zero_rdata_from_type(P) ? R : Union{R, ZeroRData}
 end
 
-zero_like_rdata_type(::TypeVar) = NoRData
+# zero_like_rdata_type(::TypeVar) = NoRData
 
 """
     zero_like_rdata_from_type(::Type{P}) where {P}

--- a/test/interpreter/zero_like_rdata.jl
+++ b/test/interpreter/zero_like_rdata.jl
@@ -6,7 +6,7 @@
             Float64,
             Int,
             Vector{Float64},
-            TypeVar(:a),
+            # TypeVar(:a),
         ]
             @test Mooncake.zero_like_rdata_from_type(P) isa Mooncake.zero_like_rdata_type(P)
         end

--- a/test/interpreter/zero_like_rdata.jl
+++ b/test/interpreter/zero_like_rdata.jl
@@ -6,7 +6,6 @@
             Float64,
             Int,
             Vector{Float64},
-            # TypeVar(:a),
         ]
             @test Mooncake.zero_like_rdata_from_type(P) isa Mooncake.zero_like_rdata_type(P)
         end

--- a/test/interpreter/zero_like_rdata.jl
+++ b/test/interpreter/zero_like_rdata.jl
@@ -1,12 +1,6 @@
 @testset "zero_like_rdata" begin
     @testset "zero_like_rdata_from_type" begin
-        @testset "$P" for P in Any[
-            @NamedTuple{a},
-            Tuple{Any},
-            Float64,
-            Int,
-            Vector{Float64},
-        ]
+        @testset "$P" for P in [@NamedTuple{a}, Tuple{Any}, Float64, Int, Vector{Float64}]
             @test Mooncake.zero_like_rdata_from_type(P) isa Mooncake.zero_like_rdata_type(P)
         end
     end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I'm opening this as an easy way to run the entire test suite to see what fails when I remove this. Do not merge.

update: this actually can be merged -- it looks like these method were redundant. They don't make any sense anyway because a `TypeVar` is not a type, so they really ought not to exist. I'll update, bump the patch, and merge when CI passes.