### PR TITLE
Fix foreigncall test suite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/foreigncall.jl
+++ b/src/rrules/foreigncall.jl
@@ -303,6 +303,7 @@ function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:foreigncall})
     _b, _db = randn(4), randn(4)
     ptr_a, ptr_da = pointer(_a), pointer(_da)
     ptr_b, ptr_db = pointer(_b), pointer(_db)
+    memory = Any[_x, _a, _da, _b, _db]
 
     test_cases = [
         (false, :none, nothing, reshape, randn(5, 4), (4, 5)),
@@ -335,6 +336,5 @@ function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:foreigncall})
             unsafe_copyto!, CoDual(ptr_a, ptr_da), CoDual(ptr_b, ptr_db), 4,
         ),
     ]
-    memory = Any[_x]
     return test_cases, memory
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
The foreigncall rrule test suite reliably segfaults due to user-error (I failed to properly preserve the data underlying some pointers I'm using in some tests).