### PR TITLE
Fix TypeStableStruct constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.17"
+version = "0.4.18"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -80,8 +80,8 @@ end
 struct TypeStableStruct{T}
     a::Int
     b::T
-    TypeStableStruct{T}(a::Float64) where {T} = new{T}(a)
-    TypeStableStruct{T}(a::Float64, b::T) where {T} = new{T}(a, b)
+    TypeStableStruct{T}(a::Int) where {T} = new{T}(a)
+    TypeStableStruct{T}(a::Int, b::T) where {T} = new{T}(a, b)
 end
 
 struct TypeUnstableStruct2


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
As pointed out by @sunxd3 a while ago, the `TypeStableStruct` inner constructors are nonsense. This PR fixes them, and resolves #221 . I'll bump the patch version + merge once #299 has been merged.