### PR TITLE
Correctly handle PartialTypeVars in inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.19"
+version = "0.4.20"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.18"
+version = "0.4.19"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -112,10 +112,11 @@ else
     get_inference_world(interp::CC.AbstractInterpreter) = CC.get_inference_world(interp)
 end
 
-_type(x) = x
+_type(x::Type) = x
 _type(x::CC.Const) = _typeof(x.val)
 _type(x::CC.PartialStruct) = x.typ
 _type(x::CC.Conditional) = Union{_type(x.thentype), _type(x.elsetype)}
+_type(::CC.PartialTypeVar) = TypeVar
 
 struct NoInlineCallInfo <: CC.CallInfo
     info::CC.CallInfo # wrapped call

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -71,7 +71,8 @@ using Mooncake:
     verify_rdata_value,
     is_primitive,
     MinimalCtx,
-    stmt
+    stmt,
+    _type
 
 using .TestUtils:
     test_rule,

--- a/test/interpreter/abstract_interpretation.jl
+++ b/test/interpreter/abstract_interpretation.jl
@@ -67,4 +67,8 @@ contains_primitive_behind_call(x) = @inline contains_primitive(x)
             @test stmt(ad_ir.stmts)[invoke_line].args[2] == GlobalRef(Main, :a_primitive)
         end
     end
+    @testset "_type" begin
+        @test _type(CC.Const(5.0)) === Float64
+        @test _type(CC.PartialTypeVar(TypeVar(:a, Union{}, Any), true, true)) === TypeVar
+    end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Should resolve the new problem in #282 .

Occasionally, the inference result associated to an SSA is `Core.Compiler.PartialTypeVar`. This means that inference has successfully determined that the SSA will be a `TypeVar`. More than that, it has figured out some of the runtime information about the SSA, in a similar sense (I believe) to the way that `Core.Compiler.PartialStruct` knows some runtime information about a given `struct`. I've asked on slack for a MWE of a function in which this is the result of inference. I'll wait a few hours, but will merge this with the current unit test if I nothing appears.

edit: many of the people who would know about this are based in the US. I'll get this merged asap, and make a new PR if an MWE becomes available.