### PR TITLE
PiNodes with GlobalRefs and Constants

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.18"
+version = "0.4.19"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -921,10 +921,10 @@ function build_rrule(
             # @show sig_or_mi
             # @show Treturn
             # @show debug_mode
-            display(ir)
+            # display(ir)
             # display(IRCode(fwds_ir))
             # display(IRCode(pb_ir))
-            display(optimised_fwds_ir)
+            # display(optimised_fwds_ir)
             # display(optimised_pb_ir)
             # @show length(stmt(ir.stmts))
             # @show length(stmt(optimised_fwds_ir.stmts))

--- a/test/integration_testing/distributions.jl
+++ b/test/integration_testing/distributions.jl
@@ -227,15 +227,21 @@ _pdmat(A) = PDMat(_sym(A) + 5I)
         ),
         (
             :none,
-            "allocs Normal",
+            "truncated Normal",
             (a, b, x) -> logpdf(truncated(Normal(), a, b), x),
             (-0.3, 0.3, 0.1),
         ),
         (
             :none,
-            "allocs Uniform",
+            "truncated Uniform",
             (a, b, α, β, x) -> logpdf(truncated(Uniform(α, β), a, b), x),
             (0.1, 0.9, -0.1, 1.1, 0.4),
+        ),
+        (
+            :none,
+            "left-truncated Beta",
+            (a, α, β, x) -> logpdf(truncated(Beta(α, β), lower=a), x),
+            (0.1, 1.1, 1.3, 0.4),
         ),
         (:none, "Dirichlet", (a, x) -> logpdf(Dirichlet(a), [x, 1-x]), ([1.5, 1.1], 0.6)),
         (

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -137,11 +137,34 @@ end
                 stmt_info = make_ad_stmts!(PiNode(nothing, Union{}), line, info)
                 @test stmt_info isa ADStmtInfo
             end
-            @testset "unhandled case" begin
-                @test_throws(
-                    Mooncake.UnhandledLanguageFeatureException,
-                    make_ad_stmts!(PiNode(5.0, Float64), ID(), info),
-                )
+            @testset "π (nothing, Nothing)" begin
+                stmt_info = make_ad_stmts!(PiNode(nothing, Nothing), id_line_1, info)
+                @test stmt_info isa ADStmtInfo
+                fwds_stmt = only(stmt_info.fwds)[2].stmt
+                @test fwds_stmt isa PiNode
+                @test fwds_stmt.val == CoDual(nothing, NoFData())
+                @test fwds_stmt.typ == CoDual{Nothing, NoFData}
+                @test only(stmt_info.rvs)[2].stmt === nothing
+            end
+            @testset "π (nothing, CC.Const(nothing))" begin
+                node = PiNode(nothing, CC.Const(nothing))
+                stmt_info = make_ad_stmts!(node, id_line_1, info)
+                @test stmt_info isa ADStmtInfo
+                fwds_stmt = only(stmt_info.fwds)[2].stmt
+                @test fwds_stmt isa PiNode
+                @test fwds_stmt.val == CoDual(nothing, NoFData())
+                @test fwds_stmt.typ == CoDual{Nothing, NoFData}
+                @test only(stmt_info.rvs)[2].stmt === nothing
+            end
+            @testset "π (GlobalRef, Type)" begin
+                node = PiNode(GlobalRef(S2SGlobals, :const_float), Any)
+                stmt_info = make_ad_stmts!(node, id_line_1, info)
+                @test stmt_info isa ADStmtInfo
+                fwds_stmt = only(stmt_info.fwds)[2].stmt
+                @test fwds_stmt isa PiNode
+                @test fwds_stmt.val == CoDual(5.0, NoFData())
+                @test fwds_stmt.typ == CoDual
+                @test only(stmt_info.rvs)[2].stmt === nothing
             end
             @testset "sharpen type of ID" begin
                 line = id_line_1


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
It appears to be the case that, as of 1.11, `PiNode`s are encountered in the wild which can contain constants. While I don't fully understand why these are necessary, handling them seems important to get e.g. Distributions.jl tests with certain kinds of truncations to work properly.

I believe that this will resolve #303 .