### PR TITLE
Prevent Stack Overflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.21"
+version = "0.4.22"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1195,7 +1195,7 @@ function pullback_ir(
         rvs_block = BBlock(blk_id, vcat(comms_insts, rvs_ad_stmts, additional_stmts))
         return vcat(rvs_block, new_blocks)
     end
-    main_blocks = vcat(main_blocks...)
+    main_blocks = reduce(vcat, main_blocks)
 
     # Create an exit block. Dereferences reverse-data for arguments, increments a zero rdata
     # against it to ensure that it is of the correct type, and returns it.


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Resolves a problem that @sunxd3 encountered when generating a large unrolled IR.

I've yet to produce a MWR, but will attempt to do so before merging. @sunxd3 could you run this branch on your problem to confirm that it indeed resolves the issue? (it does on my machine, I'm just keen to ensure that it does also on other machines)

edit: I do not understand _why_ this resolves the problem. Presumably there is some limitation of `vcat(x...)` that tends not to be hit.