### PR TITLE
Fix problem with unbound type parameters

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.23"
+version = "0.4.24"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -219,6 +219,12 @@ __ref(P) = new_inst(Expr(:call, __make_ref, P))
     return :(Ref{$R}(Mooncake.zero_like_rdata_from_type($_P)))
 end
 
+# This specialised method is necessary to ensure that `__make_ref` works properly for
+# `DataType`s with unbound type parameters. See `TestResources.typevar_tester` for an
+# example. The above method requires that `P` be a type in which all parameters are fully-
+# bound. Strange errors occur if this property does not hold.
+@inline __make_ref(::Type{<:Type}) = Ref{NoRData}(NoRData())
+
 @inline __make_ref(::Type{Union{}}) = nothing
 
 # Returns the number of arguments that the primal function has.

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -564,7 +564,13 @@ end
 
 # The inferred type of `TypeVar(...)` is `CC.PartialTypeVar`. Thanks to Jameson Nash for
 # pointing out this pleasantly simple test case.
-partial_type_var() = TypeVar(:a, Union{}, Any)
+partial_typevar_tester() = TypeVar(:a, Union{}, Any)
+
+function typevar_tester()
+    tv = Core._typevar(:a, Union{}, Any)
+    t = Core.apply_type(AbstractArray, tv, 1)
+    return UnionAll(tv, t)
+end
 
 function generate_test_functions()
     return Any[
@@ -742,7 +748,8 @@ function generate_test_functions()
         (false, :allocs, nothing, inlinable_invoke_call, 5.0),
         (false, :none, nothing, inlinable_vararg_invoke_call, (2, 2), 5.0, 4.0, 3.0, 2.0),
         (false, :none, nothing, hvcat, (2, 2), 3.0, 2.0, 0.0, 1.0),
-        (false, :none, nothing, partial_type_var),
+        (false, :none, nothing, partial_typevar_tester),
+        (false, :none, nothing, typevar_tester),
     ]
 end
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Functions which have signatures like `foo(::Type{P}) where {P}` don't play nicely with instances of `P` which have unbound type variables. If `foo` happens to be generated, the error does not look like what you would expect to get.

This PR resolves this problem by ensuring that that code path never gets hit for `__make_ref`, as this was causing problems in AdvancedVI. I've added a test which makes use of low-level machinery, to hopefully ensure that this doesn't become a problem again.