### PR TITLE
Improve debug mode and permit all IEEEFloats in ADgradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.24"
+version = "0.4.25"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -718,6 +718,13 @@ function DerivedRule(
     return DerivedRule{Tprimal, Tfwds_oc, Tpb_oc, Tisva, Tnargs}(fwds_oc, pb_oc, isva, nargs)
 end
 
+# Extends functionality defined for debug_mode.
+function verify_args(::DerivedRule{sig}, ::Tx) where {sig, Tx}
+    sig === Tx && return nothing
+    msg = "Arguments with sig $Tx do not match signature expected by rule, $sig"
+    throw(ArgumentError(msg))
+end
+
 _copy(::Nothing) = nothing
 
 function _copy(x::P) where {P<:DerivedRule}

--- a/test/debug_mode.jl
+++ b/test/debug_mode.jl
@@ -1,5 +1,13 @@
 @testset "debug_mode" begin
 
+    # Unless we explicitly check that the arguments are of the type as expected by the rule,
+    # this will segfault.
+    @testset "argument checking" begin
+        f = x -> 5x
+        rule = build_rrule(f, 5.0; debug_mode=true)
+        @test_throws ErrorException rule(zero_fcodual(f), CoDual(0f0, 1f0))
+    end
+
     # Forwards-pass tests.
     x = (CoDual(sin, NoTangent()), CoDual(5.0, NoFData()))
     @test_throws(ErrorException, Mooncake.DebugRRule(rrule!!)(x...))


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Improves debug_mode by additionally checking whether the primals of the arguments passed to a rule as the ones that the rule expects. Not doing this seems to cause segfaults occasionally.

