### PR TITLE
Fix Memory Allocation Perf in 1.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.27"
+version = "0.4.28"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -380,7 +380,16 @@ end
 
 # _new_ and _new_-adjacent rules for Memory, MemoryRef, and Array.
 
-@zero_adjoint MinimalCtx Tuple{Type{<:Memory}, UndefInitializer, Int}
+@is_primitive MinimalCtx Tuple{Type{<:Memory}, UndefInitializer, Int}
+function rrule!!(
+    ::CoDual{Type{Memory{P}}},
+    ::CoDual{UndefInitializer},
+    n::CoDual{Int},
+) where {P}
+    x = Memory{P}(undef, primal(n))
+    dx = Memory{tangent_type(P)}(undef, primal(n))
+    return CoDual(x, dx), NoPullback((NoRData(), NoRData(), NoRData()))
+end
 
 function rrule!!(
     ::CoDual{typeof(_new_)},

--- a/test/rrules/memory.jl
+++ b/test/rrules/memory.jl
@@ -1,8 +1,16 @@
 using Mooncake: generate_data_test_cases
 
+function generate_mem()
+    return rrule!!(zero_fcodual(Memory{Float64}), zero_fcodual(undef), zero_fcodual(10))
+end
+
 @testset "memory" begin
     @testset "$(typeof(p))" for p in generate_data_test_cases(StableRNG, Val(:memory))
         TestUtils.test_data(sr(123), p)
     end
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:memory))
+
+    # Check that the rule for `Memory{P}` only produces two allocations.
+    generate_mem()
+    @test 2 >= @allocations generate_mem()
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
The rrule!! for the allocation of fresh `Memory` objects had a performance issue. This PR fixes it, and adds a regression test.