### PR TITLE
Fix Remaining SpecialFunctions Limitations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.27"
+version = "0.4.28"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -673,6 +673,7 @@ __make_codual(x::P) where {P} = (P <: CoDual ? x : uninit_fcodual(x))::CoDual
 end
 
 @inline increment_if_ref!(ref::Ref, rvs_data) = increment_ref!(ref, rvs_data)
+@inline increment_if_ref!(::Ref, ::ZeroRData) = nothing
 @inline increment_if_ref!(::Nothing, ::Any) = nothing
 
 @inline increment_ref!(x::Ref, t) = setindex!(x, increment!!(x[], t))

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -235,6 +235,11 @@ const __x_for_gref_tester_4::Float64 = 3.0
 __x_for_gref_tester_5 = 5.0
 @eval globalref_tester_5() = $(GlobalRef(@__MODULE__, :__x_for_gref_tester_5))
 
+# See https://github.com/compintell/Mooncake.jl/issues/329 .
+const __x = randn(10)
+@noinline globalref_tester_6_inner(x) = sum(x)
+globalref_tester_6() = globalref_tester_6_inner(__x)
+
 type_unstable_tester_0(x::Ref{Any}) = x[]
 
 type_unstable_tester(x::Ref{Any}) = cos(x[])
@@ -604,6 +609,7 @@ function generate_test_functions()
         (false, :allocs, nothing, globalref_tester_3),
         (false, :allocs, nothing, globalref_tester_4),
         (false, :none, nothing, globalref_tester_5),
+        (false, :allocs, nothing, globalref_tester_6),
         (false, :none, (lb=1, ub=1_000), type_unstable_tester_0, Ref{Any}(5.0)),
         (false, :none, nothing, type_unstable_tester, Ref{Any}(5.0)),
         (false, :none, nothing, type_unstable_tester_2, Ref{Real}(5.0)),

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -235,6 +235,7 @@ Convert a Mooncake tangent into a type that ChainRules.jl `rrule`s expect to see
 to_cr_tangent(t::IEEEFloat) = t
 to_cr_tangent(t::Array{<:IEEEFloat}) = t
 to_cr_tangent(::NoTangent) = ChainRulesCore.NoTangent()
+to_cr_tangent(t::Tuple) = ChainRulesCore.Tangent{Any}(t...)
 
 """
     increment_and_get_rdata!(fdata, zero_rdata, cr_tangent)

--- a/test/ext/special_functions/special_functions.jl
+++ b/test/ext/special_functions/special_functions.jl
@@ -33,7 +33,7 @@ using Mooncake, SpecialFunctions, Test
         (:stability_and_allocs, polygamma, 3, 0.1),
         (:stability_and_allocs, beta, 0.3, 0.1),
         (:stability_and_allocs, logbeta, 0.3, 0.1),
-        # (:stability_and_allocs, logabsgamma, 0.3),
+        (:stability_and_allocs, logabsgamma, 0.3),
         (:stability_and_allocs, loggamma, 0.3),
         (:stability_and_allocs, expint, 0.3),
         (:stability_and_allocs, expintx, 0.3),
@@ -56,7 +56,7 @@ using Mooncake, SpecialFunctions, Test
         (:allocs, SpecialFunctions.rgammax, 3.0, 6.0),
         (:allocs, SpecialFunctions.rgamma1pm1, 0.1),
         # (:allocs, SpecialFunctions.auxgam, 0.1), # allocations
-        # (:allocs, logabsbeta, 0.3, 0.1), # logabsgamma needs to work for this to work
+        (:allocs, logabsbeta, 0.3, 0.1),
         # (:allocs, SpecialFunctions.loggamma1p, 0.3), # allocations
         # (:allocs, SpecialFunctions.loggamma1p, -0.3), # allocations
         # (:allocs, SpecialFunctions.lambdaeta, 5.0), # a genuine bug!

--- a/test/ext/special_functions/special_functions.jl
+++ b/test/ext/special_functions/special_functions.jl
@@ -59,7 +59,7 @@ using Mooncake, SpecialFunctions, Test
         (:allocs, logabsbeta, 0.3, 0.1),
         # (:allocs, SpecialFunctions.loggamma1p, 0.3), # allocations
         # (:allocs, SpecialFunctions.loggamma1p, -0.3), # allocations
-        # (:allocs, SpecialFunctions.lambdaeta, 5.0), # a genuine bug!
+        (:none, SpecialFunctions.lambdaeta, 5.0),
     ]
         test_rule(Xoshiro(123456), f, x...; perf_flag, is_primitive=false)
     end

--- a/test/ext/special_functions/special_functions.jl
+++ b/test/ext/special_functions/special_functions.jl
@@ -55,10 +55,10 @@ using Mooncake, SpecialFunctions, Test
         (:allocs, SpecialFunctions.gammax, 1.0),
         (:allocs, SpecialFunctions.rgammax, 3.0, 6.0),
         (:allocs, SpecialFunctions.rgamma1pm1, 0.1),
-        # (:allocs, SpecialFunctions.auxgam, 0.1), # allocations
+        (:allocs, SpecialFunctions.auxgam, 0.1),
         (:allocs, logabsbeta, 0.3, 0.1),
-        # (:allocs, SpecialFunctions.loggamma1p, 0.3), # allocations
-        # (:allocs, SpecialFunctions.loggamma1p, -0.3), # allocations
+        (:allocs, SpecialFunctions.loggamma1p, 0.3),
+        (:allocs, SpecialFunctions.loggamma1p, -0.3),
         (:none, SpecialFunctions.lambdaeta, 5.0),
     ]
         test_rule(Xoshiro(123456), f, x...; perf_flag, is_primitive=false)

--- a/test/tools_for_rules.jl
+++ b/test/tools_for_rules.jl
@@ -115,6 +115,7 @@ end
             (5.0, 5.0),
             (ones(5), ones(5)),
             (NoTangent(), ChainRulesCore.NoTangent()),
+            ((5.0, 4.0), ChainRulesCore.Tangent{Any}(5.0, 4.0)),
         ]
             @test Mooncake.to_cr_tangent(t) == t_cr
         end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Per #330 there are some limitations associated to SpecialFunctions.jl left over from yesterday's work. This PR will fix them, and close this issue. As part of this, it will also resolve #329 , as this is causing some derived rules for SpecialFunctions to allocate when they ought not to.