### PR TITLE
Add LogExpFunctions integration testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,7 @@ jobs:
           - 'integration_testing/diff_tests'
           - 'integration_testing/distributions'
           - 'integration_testing/gp'
+          - 'integration_testing/logexpfunctions'
           - 'integration_testing/lux'
           - 'integration_testing/misc'
           - 'integration_testing/misc_abstract_array'

--- a/test/integration_testing/logexpfunctions/Project.toml
+++ b/test/integration_testing/logexpfunctions/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/integration_testing/logexpfunctions/logexpfunctions.jl
+++ b/test/integration_testing/logexpfunctions/logexpfunctions.jl
@@ -1,0 +1,43 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.develop(; path=joinpath(@__DIR__, "..", "..", ".."))
+
+using LogExpFunctions, Mooncake, Test
+
+@testset "logexpfunctions" begin
+    @testset for (perf_flag, f, x...) in [
+        (:allocs, xlogx, 1.1),
+        (:allocs, xlogy, 0.3, 1.2),
+        (:allocs, xlog1py, 0.3, -0.5),
+        (:allocs, xexpx, -0.5),
+        (:allocs, xexpy, 1.0, -0.7),
+        (:allocs, logistic, 0.5),
+        (:allocs, logit, 0.3),
+        (:allocs, logcosh, 1.5),
+        (:allocs, logabssinh, 0.3),
+        (:allocs, log1psq, 0.3),
+        (:allocs, log1pexp, 0.1),
+        (:allocs, log1mexp, -0.5),
+        (:allocs, log2mexp, 0.1),
+        (:allocs, logexpm1, 0.1),
+        (:allocs, log1pmx, -0.95),
+        (:allocs, logmxp1, 0.02),
+        (:allocs, logaddexp, -0.5, 0.4),
+        (:allocs, logsubexp, -0.5, -5.0),
+        (:allocs, logsumexp, randn(5)),
+        (:allocs, logsumexp, randn(5, 4)),
+        (:allocs, logsumexp, randn(5, 4, 3)),
+        (:none, x -> logsumexp(x; dims=1), randn(5, 4)),
+        (:none, x -> logsumexp(x; dims=2), randn(5, 4)),
+        (:none, logsumexp!, rand(5), randn(5, 4)),
+        (:none, softmax, randn(10)),
+        (:allocs, cloglog, 0.5),
+        (:allocs, cexpexp, -0.3),
+        (:allocs, loglogistic, 0.5),
+        (:allocs, logitexp, -0.3),
+        (:allocs, log1mlogistic, -0.9),
+        (:allocs, logit1mexp, -0.6),
+    ]
+        test_rule(Xoshiro(123456), f, x...; perf_flag, is_primitive=false)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,8 @@ include("front_matter.jl")
         include(joinpath("integration_testing", "distributions", "distributions.jl"))
     elseif test_group == "integration_testing/gp"
         include(joinpath("integration_testing", "gp", "gp.jl"))
+    elseif test_group == "integration_testing/logexpfunctions"
+        include(joinpath("integration_testing", "logexpfunctions", "logexpfunctions.jl"))
     elseif test_group == "integration_testing/lux"
         include(joinpath("integration_testing", "lux", "lux.jl"))
     elseif test_group == "integration_testing/misc"


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I realised that we're not currently testing against LogExpFunctions, which feels like an oversight. Happily, it doesn't look like we need any of the rules defined in that package in order to get correctness, and to ensure that things which ought not allocate to not in fact allocate.