### PR TITLE
Improve error messages generated by the Mooncake compiler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.29"
+version = "0.4.30"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -214,9 +214,20 @@ function lookup_ir(interp::CC.AbstractInterpreter, tt::Type{<:Tuple}; optimize_u
         end
     end
     if isempty(asts)
-        throw(ArgumentError("No methods found for signature $asts"))
+        msg = "No methods found for signature: $tt.\n" *
+            "\n" *
+            "This is often caused by accidentally trying to get Mooncake.jl to " *
+            "differentiate a call (directly or indirectly) which does not exist. For " *
+            "example, defining\n" *
+            "\n" *
+            "f(x::Float64) = sin(x)\n" *
+            "build_rrule(Tuple{typeof(f), Int})\n" *
+            "\n" *
+            "would cause this error, because there are no methods of `f` which accept\n" *
+            "an `Int` argument."
+        throw(ArgumentError(msg))
     elseif length(asts) > 1
-        throw(ArgumentError("$(length(asts)) methods found for signature $sig"))
+        throw(ArgumentError("More than one method found for signature $sig."))
     end
     return only(asts)
 end

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -223,7 +223,7 @@ function lookup_ir(interp::CC.AbstractInterpreter, tt::Type{<:Tuple}; optimize_u
             "f(x::Float64) = sin(x)\n" *
             "build_rrule(Tuple{typeof(f), Int})\n" *
             "\n" *
-            "would cause this error, because there are no methods of `f` which accept\n" *
+            "would cause this error, because there are no methods of `f` which accept " *
             "an `Int` argument."
         throw(ArgumentError(msg))
     elseif length(asts) > 1

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -860,6 +860,11 @@ function Base.showerror(io::IO, err::MooncakeRuleCompilationError)
         "To replicate this error run the following:\n"
     println(io, msg)
     println(io, "Mooncake.build_rrule(Mooncake.$(err.interp), $(err.sig); debug_mode=$(err.debug_mode))")
+    println(
+        io,
+        "\nNote that you may need to `using` some additional packages if not all of the " *
+        "names printed in the above signature are available currently in your environment."
+    )
 end
 
 """

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -258,6 +258,9 @@ end
         rule = build_rrule(fargs...)
         @test_throws Mooncake.BadRuleTypeException rule(map(zero_fcodual, fargs)...)
     end
+    @testset "MooncakeRuleCompilationError" begin
+        @test_throws(Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(sin))
+    end
     @testset "$(_typeof((f, x...)))" for (n, (interface_only, perf_flag, bnds, f, x...)) in
         collect(enumerate(TestResources.generate_test_functions()))
 

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -293,7 +293,7 @@ end
 
     @testset "integration testing for invalid global ref errors" begin
         @test_throws(
-            Mooncake.UnhandledLanguageFeatureException,
+            Mooncake.Mooncake.MooncakeRuleCompilationError,
             Mooncake.build_rrule(
                 Tuple{typeof(Mooncake.TestResources.non_const_global_ref), Float64},
             )


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Addresses the remainder of #326 .

The error message associated to the `UpsilonNode` problem as been improved. With the new error messages, you would have seen something like:
```julia
  caused by: Mooncake.UnhandledLanguageFeatureException("Encountered UpsilonNode: ϒ (%2). These are generated as part of some try / catch / finally blocks. At the present time, Mooncake.jl cannot differentiate through these, so they must be avoided. Strategies for resolving this error include re-writing code such that it avoids generating any UpsilonNodes, or writing a rule to differentiate the code by hand. If you are in any doubt as to what to do, please request assistance by opening an issue at github.com/compintell/Mooncake.jl.")
  Stacktrace:
    [1] unhandled_feature(msg::String)
      @ Mooncake ~/.julia/dev/Mooncake/src/interpreter/ir_utils.jl:272
    [2] make_ad_stmts!(stmt::Core.UpsilonNode, ::ID, ::ADInfo)
      @ Mooncake ~/.julia/dev/Mooncake/src/interpreter/s2s_reverse_mode_ad.jl:477
    [3] _broadcast_getindex_evalf
      @ ./broadcast.jl:709 [inlined]
    [4] _broadcast_getindex
      @ ./broadcast.jl:682 [inlined]
    [5] getindex
      @ ./broadcast.jl:636 [inlined]
    [6] macro expansion
      @ ./broadcast.jl:1004 [inlined]
    [7] macro expansion
      @ ./simdloop.jl:77 [inlined]
    [8] copyto!
      @ ./broadcast.jl:1003 [inlined]
    [9] copyto!
      @ ./broadcast.jl:956 [inlined]
   [10] copy
      @ ./broadcast.jl:928 [inlined]
   [11] materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(make_ad_stmts!), Tuple{Vector{Any}, Vector{ID}, Base.RefValue{ADInfo}}})
      @ Base.Broadcast ./broadcast.jl:903
   [12] (::Mooncake.var"#212#214"{ADInfo})(primal_blk::BBlock)
      @ Mooncake ~/.julia/dev/Mooncake/src/interpreter/s2s_reverse_mode_ad.jl:947
   [13] iterate
      @ ./generator.jl:47 [inlined]
```

Additionally, I've added more context and information whenever Mooncake throws an error during when deriving a rule. So when the above error is thrown, you would _also_ have seen something like:
```julia
  caused by: MooncakeRuleCompilationError: an error occured while Mooncake was compiling a rule to differentiate something. If the `caused by` error message below does not make it clear to you how the problem can be fixed, please open an issue at github.com/compintell/Mooncake.jl describing your problem.
  To replicate this error run the following:
  
  Mooncake.build_rrule(Mooncake.MooncakeInterpreter(), Tuple{Base.MPFR.var"##setprecision#25", Base.Pairs{Symbol, Union{}, Tuple{}, @NamedTuple{}}, typeof(setprecision), Base.var"#909#910"{Float64, IrrationalConstants.Invsqrt2, RoundingMode{:Down}}, Type{BigFloat}, Int64}; debug_mode=false)
  
  Note that you may need to `using` some additional packages if not all of the names printed in the above signature are available currently in your environment.
  
  Stacktrace:
    [1] build_rrule(interp::Mooncake.MooncakeInterpreter{DefaultCtx}, sig_or_mi::Core.MethodInstance; debug_mode::Bool, silence_debug_messages::Bool)
      @ Mooncake ~/.julia/dev/Mooncake/src/interpreter/s2s_reverse_mode_ad.jl:994
    [2] build_rrule
      @ ~/.julia/dev/Mooncake/src/interpreter/s2s_reverse_mode_ad.jl:897 [inlined]
```