### PR TITLE
Remove some literals from shared data

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.32"
+version = "0.4.33"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -315,7 +315,6 @@ end
         rule = Mooncake.build_rrule(f, 0.0)
         @benchmark Mooncake.value_and_gradient!!($rule, $f, $(Ref(0.0))[])
     end
-
     @testset "literal Strings do not appear in shared data" begin
         f() = "hello"
         rule = build_rrule(Tuple{typeof(f)})

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -315,4 +315,10 @@ end
         rule = Mooncake.build_rrule(f, 0.0)
         @benchmark Mooncake.value_and_gradient!!($rule, $f, $(Ref(0.0))[])
     end
+
+    @testset "literal Strings do not appear in shared data" begin
+        f() = "hello"
+        rule = build_rrule(Tuple{typeof(f)})
+        @test length(rule.fwds_oc.oc.captures) == 2
+    end
 end

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -317,7 +317,10 @@ end
     end
     @testset "literal Strings do not appear in shared data" begin
         f() = "hello"
-        rule = build_rrule(Tuple{typeof(f)})
-        @test length(rule.fwds_oc.oc.captures) == 2
+        @test length(build_rrule(Tuple{typeof(f)}).fwds_oc.oc.captures) == 2
+    end
+    @testset "Literal Types do not appear in shared data" begin
+        f() = Float64
+        @test length(build_rrule(Tuple{typeof(f)}).fwds_oc.oc.captures) == 2
     end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
While looking at some performance profiles over the weekend, I discovered that there was some stuff being put in shared memory that ought to just have been interpolated directly into the generated code. It is unclear whether this will have a massive performance implication anywhere, but it will certainly tidy up the shared data a bit.