### PR TITLE
Fix Rule Type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.33"
+version = "0.4.34"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -577,6 +577,8 @@ function typevar_tester()
     return UnionAll(tv, t)
 end
 
+tuple_with_union(x::Bool) = (x ? 5.0 : 5, nothing)
+
 function generate_test_functions()
     return Any[
         (false, :allocs, nothing, const_tester),

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -244,8 +244,9 @@ end
     @testset "rule_type $sig, $debug_mode" for
         sig in Any[
             Tuple{typeof(getfield), Tuple{Float64}, 1},
-            Tuple{typeof(Mooncake.TestResources.foo), Float64},
-            Tuple{typeof(Mooncake.TestResources.type_unstable_tester_0), Ref{Any}},
+            Tuple{typeof(TestResources.foo), Float64},
+            Tuple{typeof(TestResources.type_unstable_tester_0), Ref{Any}},
+            Tuple{typeof(TestResources.tuple_with_union), Bool},
         ],
         debug_mode in [true, false]
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Reverts a change that was made in https://github.com/compintell/Mooncake.jl/pull/339 . In that PR, I changed the implementation of `rule_type` in such a way that it didn't agree with what type inference produced when I actually derived a rule. This causes some problems, so I've reverted it.

A regression test has been added to catch the offending case, found by @penelopeysm in #345 . I've checked that this fixes the problem locally.