### PR TITLE
Final Tweaks before DiffEqBase PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.44"
+version = "0.4.45"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -280,7 +280,7 @@ function benchmark_hand_written_rrules!!(rng_ctor)
         tags = fill(nothing, length(test_cases))
         return map(x -> x[4:end], test_cases), memory, ranges, tags
     end
-    return benchmark_rules!!(test_case_data, (lb=1e-3, ub=25.0), false)
+    return benchmark_rules!!(test_case_data, (lb=1e-3, ub=50.0), false)
 end
 
 function benchmark_derived_rrules!!(rng_ctor)

--- a/docs/src/running_tests_locally.md
+++ b/docs/src/running_tests_locally.md
@@ -2,9 +2,11 @@
 
 Mooncake.jl's test suite is fairly extensive. While you can use `Pkg.test` to run the test suite in the standard manner, this is not usually optimal in Mooncake.jl, and will not run all of the tests. When editing some code, you typically only want to run the tests associated with it, not the entire test suite.
 
+There are two workflows for running tests, discussed below.
+
 ## Main Testing Functionality
 
-Mooncake's tests are organised as follows:
+For all code in `src`, Mooncake's tests are organised as follows:
 1. Things that are required for most / all test suites are loaded up in `test/front_matter.jl`.
 1. The tests for something in `src` are located in an identically-named file in `test`. e.g. the unit tests for `src/rrules/new.jl` are located in `test/rrules/new.jl`.
 

--- a/src/Mooncake.jl
+++ b/src/Mooncake.jl
@@ -15,7 +15,7 @@ using
     Setfield
 
 # There are many clashing names, so we will always qualify uses of names from CRC.
-import ChainRulesCore
+import ChainRulesCore as CRC
 
 using Base:
     IEEEFloat, unsafe_convert, unsafe_pointer_to_objref, pointer_from_objref, arrayref,

--- a/src/rrules/function_wrappers.jl
+++ b/src/rrules/function_wrappers.jl
@@ -141,6 +141,10 @@ tangent(f::FunctionWrapperTangent, ::NoRData) = f
 
 _verify_fdata_value(p::FunctionWrapper, t::FunctionWrapperTangent) = nothing
 
+# Will: to the best of my knowledge, no one has ever actually worked with FunctionWrappers
+# before in the ChainRules ecosystem. Consequently, it shouldn't matter what type we use
+# here. We might need to revise this is people start making use of FunctionWrappers in a
+# meaningful way inside of ChainRules, but it seems unlikely that this will ever happen.
 to_cr_tangent(t::FunctionWrapperTangent) = t
 
 @is_primitive MinimalCtx Tuple{Type{<:FunctionWrapper}, Any}

--- a/src/rrules/function_wrappers.jl
+++ b/src/rrules/function_wrappers.jl
@@ -141,6 +141,8 @@ tangent(f::FunctionWrapperTangent, ::NoRData) = f
 
 _verify_fdata_value(p::FunctionWrapper, t::FunctionWrapperTangent) = nothing
 
+to_cr_tangent(t::FunctionWrapperTangent) = t
+
 @is_primitive MinimalCtx Tuple{Type{<:FunctionWrapper}, Any}
 function rrule!!(::CoDual{Type{FunctionWrapper{R, A}}}, obj::CoDual{P}) where {R, A, P}
     t, obj_tangent_ref = _function_wrapper_tangent(R, obj.x, A, zero_tangent(obj.x, obj.dx))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -387,7 +387,7 @@ function test_rrule_interface(f_f̄, x_x̄...; rule)
         display(e)
         println()
         throw(ArgumentError(
-            "rrule!! for $(_typeof(f_fwds)) with argument types $(_typeof(x_fwds)) does not run."
+            "rule for $(_typeof(f_fwds)) with argument types $(_typeof(x_fwds)) does not run."
         ))
     end
     @test rrule_ret isa rrule_output_type(_typeof(y))

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -234,8 +234,12 @@ Convert a Mooncake tangent into a type that ChainRules.jl `rrule`s expect to see
 """
 to_cr_tangent(t::IEEEFloat) = t
 to_cr_tangent(t::Array{<:IEEEFloat}) = t
-to_cr_tangent(::NoTangent) = ChainRulesCore.NoTangent()
-to_cr_tangent(t::Tuple) = ChainRulesCore.Tangent{Any}(t...)
+to_cr_tangent(t::Array) = map(to_cr_tangent, t)
+to_cr_tangent(::NoTangent) = CRC.NoTangent()
+to_cr_tangent(t::Tangent) = CRC.Tangent{Any}(; map(to_cr_tangent, t.fields)...)
+to_cr_tangent(t::MutableTangent) = CRC.Tangent{Any}(; map(to_cr_tangent, t.fields)...)
+to_cr_tangent(t::Tuple) = CRC.Tangent{Any}(map(to_cr_tangent, t)...)
+to_cr_tangent(t::FunctionWrapperTangent) = t
 
 """
     increment_and_get_rdata!(fdata, zero_rdata, cr_tangent)
@@ -248,9 +252,9 @@ function increment_and_get_rdata!(f::Array{P}, ::NoRData, t::Array{P}) where {P<
     increment!!(f, t)
     return NoRData()
 end
-increment_and_get_rdata!(::Any, r, ::ChainRulesCore.NoTangent) = r
-function increment_and_get_rdata!(f, r, t::ChainRulesCore.Thunk)
-    return increment_and_get_rdata!(f, r, ChainRulesCore.unthunk(t))
+increment_and_get_rdata!(::Any, r, ::CRC.NoTangent) = r
+function increment_and_get_rdata!(f, r, t::CRC.Thunk)
+    return increment_and_get_rdata!(f, r, CRC.unthunk(t))
 end
 
 @doc"""
@@ -282,7 +286,7 @@ function rrule_wrapper(fargs::Vararg{CoDual, N}) where {N}
     # Run forwards-pass.
     primals = tuple_map(primal, fargs)
     lazy_rdata = tuple_map(Mooncake.lazy_zero_rdata, primals)
-    y_primal, cr_pb = ChainRulesCore.rrule(primals...)
+    y_primal, cr_pb = CRC.rrule(primals...)
     y_fdata = fdata(zero_tangent(y_primal))
 
     function pb!!(y_rdata)
@@ -306,7 +310,7 @@ function rrule_wrapper(::CoDual{typeof(Core.kwcall)}, fargs::Vararg{CoDual, N}) 
     # Run forwards-pass.
     primals = tuple_map(primal, fargs)
     lazy_rdata = tuple_map(lazy_zero_rdata, primals)
-    y_primal, cr_pb = Core.kwcall(primals[1], ChainRulesCore.rrule, primals[2:end]...)
+    y_primal, cr_pb = Core.kwcall(primals[1], CRC.rrule, primals[2:end]...)
     y_fdata = fdata(zero_tangent(y_primal))
 
     function pb!!(y_rdata)
@@ -318,7 +322,7 @@ function rrule_wrapper(::CoDual{typeof(Core.kwcall)}, fargs::Vararg{CoDual, N}) 
         cr_dfargs = cr_pb(cr_tangent)
 
         # Increment fdata and compute rdata.
-        kwargs_rdata = rdata(zero_tangent(fargs[1]))
+        kwargs_rdata = rdata(zero_tangent(primals[1]))
         args_rdata = map(fargs[2:end], lazy_rdata[2:end], cr_dfargs) do x, l_rdata, cr_dx
             return increment_and_get_rdata!(tangent(x), instantiate(l_rdata), cr_dx)
         end

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -239,7 +239,6 @@ to_cr_tangent(::NoTangent) = CRC.NoTangent()
 to_cr_tangent(t::Tangent) = CRC.Tangent{Any}(; map(to_cr_tangent, t.fields)...)
 to_cr_tangent(t::MutableTangent) = CRC.Tangent{Any}(; map(to_cr_tangent, t.fields)...)
 to_cr_tangent(t::Tuple) = CRC.Tangent{Any}(map(to_cr_tangent, t)...)
-to_cr_tangent(t::FunctionWrapperTangent) = t
 
 """
     increment_and_get_rdata!(fdata, zero_rdata, cr_tangent)

--- a/test/rrules/function_wrappers.jl
+++ b/test/rrules/function_wrappers.jl
@@ -7,6 +7,10 @@
     ]
         TestUtils.test_tangent_consistency(rng, p)
         TestUtils.test_fwds_rvs_data(rng, p)
+
+        # Check that we can run `to_cr_tangent` on tangents for FunctionWrappers.
+        t = zero_tangent(p)
+        @test Mooncake.to_cr_tangent(t) === t
     end
     TestUtils.run_rrule!!_test_cases(StableRNG, Val(:function_wrappers))
 end

--- a/test/tools_for_rules.jl
+++ b/test/tools_for_rules.jl
@@ -128,6 +128,10 @@ end
             ((5.0, 4.0), ChainRulesCore.Tangent{Any}(5.0, 4.0)),
             ([ones(5), NoTangent()], [ones(5), ChainRulesCore.NoTangent()]),
             (
+                Tangent((a=5.0, b=NoTangent())),
+                ChainRulesCore.Tangent{Any}(; a=5.0, b=ChainRulesCore.NoTangent()),
+            ),
+            (
                 MutableTangent((a=5.0, b=ones(3))),
                 ChainRulesCore.Tangent{Any}(; a=5.0, b=ones(3)),
             ),

--- a/test/tools_for_rules.jl
+++ b/test/tools_for_rules.jl
@@ -126,6 +126,11 @@ end
             (ones(5), ones(5)),
             (NoTangent(), ChainRulesCore.NoTangent()),
             ((5.0, 4.0), ChainRulesCore.Tangent{Any}(5.0, 4.0)),
+            ([ones(5), NoTangent()], [ones(5), ChainRulesCore.NoTangent()]),
+            (
+                MutableTangent((a=5.0, b=ones(3))),
+                ChainRulesCore.Tangent{Any}(; a=5.0, b=ones(3)),
+            ),
         ]
             @test Mooncake.to_cr_tangent(t) == t_cr
         end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
There are a few small things which Mooncake needs to have before the PR I want to make to DiffEqBase will work at all, so this adds this functionality. Once it's tagged + released, I'll be able to open a PR against SciMLSensitivity.