### PR TITLE
Remove some obviously redundant code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.46"
+version = "0.4.47"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/codual.jl
+++ b/src/codual.jl
@@ -101,5 +101,3 @@ end
 function fcodual_type(p::Type{Type{P}}) where {P}
     return @isdefined(P) ? CoDual{Type{P}, NoFData} : CoDual{_typeof(p), NoFData}
 end
-
-zero_rdata(x::CoDual) = zero_rdata(primal(x))

--- a/src/interpreter/bbcode.jl
+++ b/src/interpreter/bbcode.jl
@@ -580,12 +580,6 @@ end
 _to_ssas(d::Dict, x::IDGotoNode) = GotoNode(d[x.label].id)
 _to_ssas(d::Dict, x::IDGotoIfNot) = GotoIfNot(get(d, x.cond, x.cond), d[x.dest].id)
 
-# Compute the CFG associated to `insts`. All references to blocks must be references to
-# the SSAValue associated to the first statement in the block.
-function _compute_basic_blocks(insts::InstVector)
-    return CC.compute_basic_blocks(Any[inst.stmt for inst in insts])
-end
-
 # Replaces references to blocks by line-number with references to block numbers.
 function _lines_to_blocks(insts::InstVector, cfg::CC.CFG)
     return map(inst -> __lines_to_blocks(cfg, inst), insts)

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -313,6 +313,8 @@ end
     replace_uses_with!(stmt, def::Union{Argument, SSAValue}, val)
 
 Replace all uses of `def` with `val` in the single statement `stmt`.
+Note: this function is highly incomplete, really only working correctly for a specific
+function in `ir_normalisation.jl`. You probably do not want to use it.
 """
 function replace_uses_with!(stmt, def::Union{Argument, SSAValue}, val)
     if stmt isa Expr
@@ -328,16 +330,4 @@ function replace_uses_with!(stmt, def::Union{Argument, SSAValue}, val)
     else
         return stmt
     end
-end
-
-"""
-    replace_uses_with(ir::IRCode, def::Union{Argument, SSAValue}, val)
-
-Replace all uses of `def` in `ir` with `val`.
-"""
-function replace_uses_with!(ir::IRCode, def::Union{Argument, SSAValue}, val)
-    for (n, stmt) in enumerate(stmt(ir.stmts))
-        statements[n] = replace_uses_with!(stmt, def, val)
-    end
-    return ir
 end

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -695,9 +695,6 @@ end
 @inline increment_ref!(x::Ref, t) = setindex!(x, increment!!(x[], t))
 @inline increment_ref!(::Base.RefValue{NoRData}, t) = nothing
 
-# Useful to have this function call for debugging when looking at the generated IRCode.
-@inline __pop_pb_stack!(stack) = pop!(stack)
-
 @inline function set_ret_ref_to_zero!!(::Type{P}, r::Ref{R}) where {P, R}
     r[] = zero_like_rdata_from_type(P)
 end

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -802,14 +802,6 @@ function test_from_slack(x::AbstractVector{T}) where {T}
     return y
 end
 
-function value_dependent_control_flow(x, n)
-    while n > 0
-        x = cos(x)
-        n -= 1
-    end
-    return x
-end
-
 #
 # This is a version of setfield! in which there is an issue with the address map.
 # The method of setfield! is incorrectly implemented, so it errors. This is intentional,
@@ -825,18 +817,11 @@ end
 
 function Mooncake.rrule!!(::Mooncake.CoDual{typeof(my_setfield!)}, value, name, x)
     _name = primal(name)
-    old_x = isdefined(primal(value), _name) ? getfield(primal(value), _name) : nothing
-    function setfield!_pullback(dy, df, dvalue, ::NoTangent, dx)
-        new_dx = increment!!(dx, val(getfield(dvalue.fields, _name)))
-        new_dx = increment!!(new_dx, dy)
-        old_x !== nothing && setfield!(primal(value), _name, old_x)
-        return df, dvalue, NoTangent(), new_dx
-    end
     y = Mooncake.CoDual(
         setfield!(primal(value), _name, primal(x)),
         _setfield!(tangent(value), _name, tangent(x)),
     )
-    return y, setfield!_pullback
+    return y, nothing
 end
 
 # Tests brought in from DiffTests.jl


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I was taking a quick look through our coverage report. While there are a few things which will require some actual work to improve, there are a number of things which are completely redundant. Presumably at some point they were used for something, but now it appears that they are not.