### PR TITLE
Perf and Pre-Allocation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.50"
+version = "0.4.51"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -784,7 +784,7 @@ tangent_type(::Type{NoFData}, ::Type{R}) where {R<:IEEEFloat} = R
 tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
 # Tuples
-function tangent_type(::Type{F}, ::Type{R}) where {F<:Tuple,R<:Tuple}
+@generated function tangent_type(::Type{F}, ::Type{R}) where {F<:Tuple,R<:Tuple}
     return Tuple{tuple_map(tangent_type, Tuple(F.parameters), Tuple(R.parameters))...}
 end
 function tangent_type(::Type{NoFData}, ::Type{R}) where {R<:Tuple}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -196,7 +196,7 @@ function prepare_pullback_cache(fx...; kwargs...)
 
     # Construct cache for output. Check that `copy!`ing appears to work.
     y_cache = copy(primal(y))
-    return Cache(rule,  _copy!!(y_cache, primal(y)), tangents)
+    return Cache(rule, _copy!!(y_cache, primal(y)), tangents)
 end
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -196,13 +196,7 @@ function prepare_pullback_cache(fx...; kwargs...)
 
     # Construct cache for output. Check that `copy!`ing appears to work.
     y_cache = copy(primal(y))
-    try
-        _copy!!(y_cache, primal(y))
-    catch
-        error("Unable to apply `copy!` to the output.")
-    end
-
-    return Cache(rule, y_cache, tangents)
+    return Cache(rule,  _copy!!(y_cache, primal(y)), tangents)
 end
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,5 @@
 """
-    __value_and_pullback!!(rule, ȳ, f::CoDual, x::CoDual...)
+    __value_and_pullback!!(rule, ȳ, f::CoDual, x::CoDual...; y_cache=nothing)
 
 *Note:* this is not part of the public Mooncake.jl interface, and may change without warning.
 
@@ -8,13 +8,15 @@ In-place version of `value_and_pullback!!` in which the arguments have been wrap
 if calling this function multiple times with different values of `x`, should be careful to
 ensure that you zero-out the tangent fields of `x` each time.
 """
-function __value_and_pullback!!(rule::R, ȳ::T, fx::Vararg{CoDual,N}) where {R,N,T}
+function __value_and_pullback!!(
+    rule::R, ȳ::T, fx::Vararg{CoDual,N}; y_cache=nothing,
+) where {R,N,T}
     fx_fwds = tuple_map(to_fwds, fx)
     __verify_sig(rule, fx_fwds)
     out, pb!! = rule(fx_fwds...)
     @assert _typeof(tangent(out)) == fdata_type(T)
     increment!!(tangent(out), fdata(ȳ))
-    v = copy(primal(out))
+    v = y_cache === nothing ? copy(primal(out)) : copyto!(y_cache, primal(out))
     return v, tuple_map((f, r) -> tangent(fdata(tangent(f)), r), fx, pb!!(rdata(ȳ)))
 end
 
@@ -36,6 +38,15 @@ __verify_sig(::typeof(rrule!!), fx::Tuple) = nothing
 
 struct ValueAndGradientReturnTypeError <: Exception
     msg::String
+end
+
+function throw_val_and_grad_ret_type_error(y)
+    throw(
+        ValueAndGradientReturnTypeError(
+            "When calling __value_and_gradient!!, return value of primal must be a " *
+            "subtype of IEEEFloat. Instead, found value of type $(typeof(y)).",
+        ),
+    )
 end
 
 """
@@ -72,17 +83,7 @@ function __value_and_gradient!!(rule::R, fx::Vararg{CoDual,N}) where {R,N}
     __verify_sig(rule, fx_fwds)
     out, pb!! = rule(fx_fwds...)
     y = primal(out)
-    if !(y isa IEEEFloat)
-        throw(
-            ValueAndGradientReturnTypeError(
-                "When calling __value_and_gradient!!, return value of primal must be a " *
-                "subtype of IEEEFloat. Instead, found value of type $(typeof(y)).",
-            ),
-        )
-    end
-    @assert y isa IEEEFloat
-    @assert tangent(out) isa NoFData
-
+    y isa IEEEFloat || throw_val_and_grad_ret_type_error(y)
     return y, tuple_map((f, r) -> tangent(fdata(tangent(f)), r), fx, pb!!(one(y)))
 end
 
@@ -162,4 +163,90 @@ function __create_coduals(args)
             rethrow(e)
         end
     end
+end
+
+struct Cache{Trule, Ty_cache, Ttangents<:Tuple}
+    rule::Trule
+    y_cache::Ty_cache
+    tangents::Ttangents
+end
+
+"""
+    prepare_pullback_cache(f, x...)
+
+Returns a `cache` which can be passed to `value_and_gradient!!`. See the docstring for
+[`value_and_gradient!!`](@ref) for more info.
+"""
+function prepare_pullback_cache(fx...)
+
+    # Take a copy before mutating.
+    fx = deepcopy(fx)
+
+    # Construct rule and tangents.
+    rule = build_rrule(fx...)
+    tangents = map(zero_tangent, fx)
+
+    # Run the rule forwards -- this should do a decent chunk of pre-allocation.
+    y, _ = rule(map((x, dx) -> CoDual(x, fdata(dx)), fx, tangents)...)
+
+    # Construct cache for output. Check that `copy!`ing appears to work.
+    y_cache = copy(primal(y))
+    try
+        copy!(y_cache, primal(y))
+    catch
+        error("Unable to apply `copy!` to the output.")
+    end
+
+    return Cache(rule, y_cache, tangents)
+end
+
+"""
+    value_and_pullback!!(cache::Cache, ȳ, f, x...)
+
+Like other methods of `value_and_pullback!!`, but makes use of the `cache` object in order
+to avoid having to re-allocate various tangent objects repeatedly.
+
+You must ensure that `f` and `x` are the same types and sizes as those used to construct
+`cache`.
+
+Warning: any mutable components of values returned by `value_and_gradient!!` will be mutated
+if you run this function again with different arguments. Therefore, if you need to keep the
+values returned by this function around over multiple calls to this function with the same
+`cache`, you should take a copy of them before calling again.
+"""
+function value_and_pullback!!(cache::Cache, ȳ, fx::Vararg{Any, N}) where {N}
+    coduals = map(CoDual, fx, cache.tangents)
+    return __value_and_pullback!!(cache.rule, ȳ, coduals...; y_cache=cache.y_cache)
+end
+
+"""
+    prepare_gradient_cache(f, x...)
+
+Returns a `cache` which can be passed to `value_and_gradient!!`. See the docstring for
+[`value_and_gradient!!`](@ref) for more info.
+"""
+function prepare_gradient_cache(fx...)
+    rule = build_rrule(fx...)
+    tangents = map(zero_tangent, fx)
+    y, _ = rule(map((x, dx) -> CoDual(x, fdata(dx)), fx, tangents)...)
+    primal(y) isa IEEEFloat || throw_val_and_grad_ret_type_error(primal(y))
+    return Cache(rule, nothing, tangents)
+end
+
+"""
+    value_and_gradient!!(cache::Cache, fx::Vararg{Any, N}) where {N}
+
+Like other methods of `value_and_gradient!!`, but makes use of the `cache` object in order
+to avoid having to re-allocate various tangent objects repeatedly.
+
+You must ensure that `f` and `x` are the same types and sizes as those used to construct
+`cache`.
+
+Warning: any mutable components of values returned by `value_and_gradient!!` will be mutated
+if you run this function again with different arguments. Therefore, if you need to keep the
+values returned by this function around over multiple calls to this function with the same
+`cache`, you should take a copy of them before calling again.
+"""
+function value_and_gradient!!(cache::Cache, fx::Vararg{Any, N}) where {N}
+    return __value_and_gradient!!(cache.rule, map(CoDual, fx, cache.tangents)...)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,7 +9,7 @@ if calling this function multiple times with different values of `x`, should be 
 ensure that you zero-out the tangent fields of `x` each time.
 """
 function __value_and_pullback!!(
-    rule::R, ȳ::T, fx::Vararg{CoDual,N}; y_cache=nothing,
+    rule::R, ȳ::T, fx::Vararg{CoDual,N}; y_cache=nothing
 ) where {R,N,T}
     fx_fwds = tuple_map(to_fwds, fx)
     __verify_sig(rule, fx_fwds)
@@ -165,7 +165,7 @@ function __create_coduals(args)
     end
 end
 
-struct Cache{Trule, Ty_cache, Ttangents<:Tuple}
+struct Cache{Trule,Ty_cache,Ttangents<:Tuple}
     rule::Trule
     y_cache::Ty_cache
     tangents::Ttangents
@@ -221,7 +221,7 @@ if you run this function again with different arguments. Therefore, if you need 
 values returned by this function around over multiple calls to this function with the same
 `cache`, you should take a copy of them before calling again.
 """
-function value_and_pullback!!(cache::Cache, ȳ, fx::Vararg{Any, N}) where {N}
+function value_and_pullback!!(cache::Cache, ȳ, fx::Vararg{Any,N}) where {N}
     coduals = map(CoDual, fx, map(set_to_zero!!, cache.tangents))
     return __value_and_pullback!!(cache.rule, ȳ, coduals...; y_cache=cache.y_cache)
 end
@@ -258,7 +258,7 @@ if you run this function again with different arguments. Therefore, if you need 
 values returned by this function around over multiple calls to this function with the same
 `cache`, you should take a copy of them before calling again.
 """
-function value_and_gradient!!(cache::Cache, fx::Vararg{Any, N}) where {N}
+function value_and_gradient!!(cache::Cache, fx::Vararg{Any,N}) where {N}
     coduals = map(CoDual, fx, map(set_to_zero!!, cache.tangents))
     return __value_and_gradient!!(cache.rule, coduals...)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -127,7 +127,7 @@ Equivalent to `value_and_pullback!!(rule, 1.0, f, x...)`, and assumes `f` return
 `Float64`.
 
 *Note:* There are lots of subtle ways to mis-use `value_and_pullback!!`, so we generally
-recommend using [`Mooncake.value_and_gradient!!`](@ref) (this function) where possible. The
+recommend using `Mooncake.value_and_gradient!!` (this function) where possible. The
 docstring for `value_and_pullback!!` is useful for understanding this function though.
 
 An example:
@@ -180,7 +180,7 @@ _copy!!(::Number, src::Number) = src
 WARNING: experimental functionality. Interface subject to change without warning!
 
 Returns a `cache` which can be passed to `value_and_gradient!!`. See the docstring for
-[`Mooncake.value_and_gradient!!`](@ref) for more info.
+`Mooncake.value_and_gradient!!` for more info.
 """
 function prepare_pullback_cache(fx...; kwargs...)
 
@@ -227,7 +227,7 @@ end
 WARNING: experimental functionality. Interface subject to change without warning!
 
 Returns a `cache` which can be passed to `value_and_gradient!!`. See the docstring for
-[`Mooncake.value_and_gradient!!`](@ref) for more info.
+`Mooncake.value_and_gradient!!` for more info.
 """
 function prepare_gradient_cache(fx...; kwargs...)
     rule = build_rrule(fx...; kwargs...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -177,6 +177,8 @@ _copy!!(::Number, src::Number) = src
 """
     prepare_pullback_cache(f, x...)
 
+WARNING: experimental functionality. Interface subject to change without warning!
+
 Returns a `cache` which can be passed to `value_and_gradient!!`. See the docstring for
 [`value_and_gradient!!`](@ref) for more info.
 """
@@ -206,6 +208,8 @@ end
 """
     value_and_pullback!!(cache::Cache, ȳ, f, x...)
 
+WARNING: experimental functionality. Interface subject to change without warning!
+
 Like other methods of `value_and_pullback!!`, but makes use of the `cache` object in order
 to avoid having to re-allocate various tangent objects repeatedly.
 
@@ -225,6 +229,8 @@ end
 """
     prepare_gradient_cache(f, x...)
 
+WARNING: experimental functionality. Interface subject to change without warning!
+
 Returns a `cache` which can be passed to `value_and_gradient!!`. See the docstring for
 [`value_and_gradient!!`](@ref) for more info.
 """
@@ -238,6 +244,8 @@ end
 
 """
     value_and_gradient!!(cache::Cache, fx::Vararg{Any, N}) where {N}
+
+WARNING: experimental functionality. Interface subject to change without warning!
 
 Like other methods of `value_and_gradient!!`, but makes use of the `cache` object in order
 to avoid having to re-allocate various tangent objects repeatedly.

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -623,7 +623,7 @@ Set `x` to its zero element (`x` should be a tangent, so the zero must exist).
 """
 set_to_zero!!(::NoTangent) = NoTangent()
 set_to_zero!!(x::Base.IEEEFloat) = zero(x)
-set_to_zero!!(x::Union{Tuple,NamedTuple}) = map(set_to_zero!!, x)
+set_to_zero!!(x::Union{Tuple,NamedTuple}) = tuple_map(set_to_zero!!, x)
 function set_to_zero!!(x::T) where {T<:PossiblyUninitTangent}
     return is_init(x) ? T(set_to_zero!!(val(x))) : x
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -66,6 +66,8 @@ end
     @testset "value_and_pullback!!" begin
         @testset "($(typeof(fargs))" for (ȳ, fargs...) in Any[
             (randn(10), identity, randn(10)),
+            (randn(), sin, randn(Float64)),
+            (randn(), sum, randn(Float64)),
         ]
             rule = build_rrule(fargs...)
             f, args... = fargs

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,3 +1,9 @@
+function count_allocs(fargs::P) where {P<:Tuple}
+    f, args... = fargs
+    f(args...) # warmup
+    return @allocations f(args...)
+end
+
 @testset "interface" begin
     @testset "$(typeof((f, x...)))" for (ȳ, f, x...) in Any[
         (1.0, (x, y) -> x * y + sin(x) * cos(y), 5.0, 4.0),
@@ -28,6 +34,7 @@
             ((x, y) -> x + sin(y), randn(Float64), randn(Float64)),
             ((x, y) -> x + sin(y), randn(Float32), randn(Float32)),
             ((x...) -> x[1] + x[2], randn(Float64), randn(Float64)),
+            (sum, randn(10)),
         ]
             rule = build_rrule(fargs...)
             f, args... = fargs
@@ -36,6 +43,14 @@
             for (arg, darg) in zip(fargs, dfargs)
                 @test tangent_type(typeof(arg)) == typeof(darg)
             end
+
+            cache = Mooncake.prepare_gradient_cache(fargs...)
+            _v, _dfargs = value_and_gradient!!(cache, fargs...)
+            @test _v == v
+            for (arg, darg) in zip(fargs, _dfargs)
+                @test tangent_type(typeof(arg)) == typeof(darg)
+            end
+            @test count_allocs((value_and_gradient!!, cache, fargs...)) == 0
         end
 
         rule = build_rrule(identity, (5.0, 4.0))
@@ -43,5 +58,30 @@
             Mooncake.ValueAndGradientReturnTypeError,
             value_and_gradient!!(rule, identity, (5.0, 4.0)),
         )
+        @test_throws(
+            Mooncake.ValueAndGradientReturnTypeError,
+            Mooncake.prepare_gradient_cache(identity, (5.0, 4.0)),
+        )
+    end
+    @testset "value_and_pullback!!" begin
+        @testset "($(typeof(fargs))" for (ȳ, fargs...) in Any[
+            (randn(10), identity, randn(10)),
+        ]
+            rule = build_rrule(fargs...)
+            f, args... = fargs
+            v, dfargs = value_and_pullback!!(rule, ȳ, fargs...)
+            @test v == f(args...)
+            for (arg, darg) in zip(fargs, dfargs)
+                @test tangent_type(typeof(arg)) == typeof(darg)
+            end
+
+            cache = Mooncake.prepare_pullback_cache(fargs...)
+            _v, _dfargs = value_and_pullback!!(cache, ȳ, fargs...)
+            @test _v == v
+            for (arg, darg) in zip(fargs, _dfargs)
+                @test tangent_type(typeof(arg)) == typeof(darg)
+            end
+            @test count_allocs((value_and_pullback!!, cache, ȳ, fargs...)) == 0
+        end
     end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
This PR
1. makes a function generated, because type inference sometimes falls over for it in some situations which matter, and
2. moves the pre-allocation functionality in-house. It's largely a generalisation of stuff that's already been written in DI.jl, but having it here lets us test it thoroughly here, and then get DI.jl to just use it. This increases the level of confidence that it's possible for me to have that when a user uses DI.jl, they're getting the best possible level of performance.

Todo:
- [x] a few more tests for `value_and_pullback!!` with a cache
- [x] mark these new functions as "experimental" (I think the design is fine, but I don't want to commit to it yet)
- [x] verify locally that I'm able to use these functions to substantially simplify the implementation of the Mooncake extension in DI.jl.