### PR TITLE
Do not warn on failed return type guessing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.54"
+version = "0.4.55"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1735,14 +1735,12 @@ _rtype(T::Type{<:DerivedRule}) = Tuple{_rtype(fieldtype(T, :fwds_oc)),fieldtype(
         rule.rule = derived_rule
         result = derived_rule(args...)
     else
-        @warn "Unable to put rule in rule field. A `BadRuleTypeException` might be thrown."
         err = BadRuleTypeException(rule.mi, sig, typeof(derived_rule), Trule)
         result = try
             derived_rule(args...)
         catch
             throw(err)
         end
-        @warn "`BadRuleTypException was _not_ thrown. Expect an error at some point."
     end
     return result::_rtype(Trule)
 end

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -12,12 +12,6 @@ struct A
 end
 f(a, x) = dot(a.data, x)
 
-# Test cases designed to cause `LazyDerivedRule` to throw an error when attempting to
-# construct a rule for `bar`.
-foo(x) = x
-@noinline bar(x) = foo(x)
-baz(x) = bar(x)
-Mooncake.@is_primitive Mooncake.MinimalCtx Tuple{typeof(foo),Any}
 end
 
 @testset "s2s_reverse_mode_ad" begin
@@ -257,15 +251,6 @@ end
         interp = get_interpreter()
         rule = Mooncake.build_rrule(interp, sig; debug_mode)
         @test rule isa Mooncake.rule_type(interp, sig; debug_mode)
-    end
-    @testset "LazyDerivedRule" begin
-        fargs = (S2SGlobals.baz, 5.0)
-        rule = build_rrule(fargs...)
-        msg = "Unable to put rule in rule field. A `BadRuleTypeException` might be thrown."
-        @test_logs(
-            (:warn, msg),
-            (@test_throws Mooncake.BadRuleTypeException rule(map(zero_fcodual, fargs)...)),
-        )
     end
     @testset "MooncakeRuleCompilationError" begin
         @test_throws(Mooncake.MooncakeRuleCompilationError, Mooncake.build_rrule(sin))


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Sometimes, we're unable to correctly predict the output type of the forwards-pass of a rule. As far as I can tell, this only happens in edge-cases involving type instability, where performance is bad anyway. Importantly, it never happens when the primal is completely type-stable because the type is very predictable in those cases.

Currently we generate a warning when this happens because, historically, I only expected this to happen when something had gone badly wrong with AD. Since this isn't really the case anymore, I'm inclined to not produce the warning.