### PR TITLE
Remove hack and insist on Julia version upgrade

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -67,7 +67,7 @@ Setfield = "1"
 SpecialFunctions = "2"
 StableRNGs = "1"
 Test = "1"
-julia = "1.10"
+julia = "~1.10, 1.11.2"
 
 [extras]
 AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.57"
+version = "0.4.58"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeLuxLibSLEEFPiratesExtension.jl
+++ b/ext/MooncakeLuxLibSLEEFPiratesExtension.jl
@@ -4,56 +4,25 @@ using LuxLib, Mooncake, SLEEFPirates
 using Base: IEEEFloat
 using Mooncake: @from_rrule, DefaultCtx
 
-@static if VERSION >= v"1.11"
-
-    # Workaround for package load order problems. See
-    # https://github.com/JuliaLang/julia/issues/56204#issuecomment-2419553167 for more context.
-    function __init__()
-        Base.generating_output() && return nothing
-
-        for f in Any[
-            LuxLib.NNlib.sigmoid_fast,
-            LuxLib.NNlib.softplus,
-            LuxLib.NNlib.logsigmoid,
-            LuxLib.NNlib.swish,
-            LuxLib.NNlib.lisht,
-            Base.tanh,
-            LuxLib.NNlib.tanh_fast,
-        ]
-            f_fast = LuxLib.Impl.sleefpirates_fast_act(f)
-            @eval @from_rrule DefaultCtx Tuple{typeof($f_fast),IEEEFloat}
-            @eval @from_rrule(
-                DefaultCtx,
-                Tuple{
-                    typeof(Broadcast.broadcasted),
-                    typeof($f_fast),
-                    Union{IEEEFloat,Array{<:IEEEFloat}},
-                },
-            )
-        end
-    end
-
-else
-    for f in Any[
-        LuxLib.NNlib.sigmoid_fast,
-        LuxLib.NNlib.softplus,
-        LuxLib.NNlib.logsigmoid,
-        LuxLib.NNlib.swish,
-        LuxLib.NNlib.lisht,
-        Base.tanh,
-        LuxLib.NNlib.tanh_fast,
-    ]
-        f_fast = LuxLib.Impl.sleefpirates_fast_act(f)
-        @eval @from_rrule DefaultCtx Tuple{typeof($f_fast),IEEEFloat}
-        @eval @from_rrule(
-            DefaultCtx,
-            Tuple{
-                typeof(Broadcast.broadcasted),
-                typeof($f_fast),
-                Union{IEEEFloat,Array{<:IEEEFloat}},
-            },
-        )
-    end
+for f in Any[
+    LuxLib.NNlib.sigmoid_fast,
+    LuxLib.NNlib.softplus,
+    LuxLib.NNlib.logsigmoid,
+    LuxLib.NNlib.swish,
+    LuxLib.NNlib.lisht,
+    Base.tanh,
+    LuxLib.NNlib.tanh_fast,
+]
+    f_fast = LuxLib.Impl.sleefpirates_fast_act(f)
+    @eval @from_rrule DefaultCtx Tuple{typeof($f_fast),IEEEFloat}
+    @eval @from_rrule(
+        DefaultCtx,
+        Tuple{
+            typeof(Broadcast.broadcasted),
+            typeof($f_fast),
+            Union{IEEEFloat,Array{<:IEEEFloat}},
+        },
+    )
 end
 
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
In https://github.com/compintell/Mooncake.jl/pull/377 we introduced a hack which ensured that code was loaded in roughly the correct order when extensions depended upon other extensions. Happily this ceased to be necessary in 1.11.2, so this PR
1. removes the hacky code
2. modifies the Julia compat bound to ensure that people still running 1.11.0 or 1.11.1 do not see this problem.

