### PR TITLE
Reactivate enzyme comparison + use WithValue

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -133,7 +133,6 @@ function should_run_benchmark(
 )
     return false
 end
-should_run_benchmark(::Val{:enzyme}, x...) = false
 
 @inline g(x, a, ::Val{N}) where {N} = N > 0 ? g(x * a, a, Val(N - 1)) : x
 
@@ -236,7 +235,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
                     suite["enzyme"] = @be(
                         _,
                         _,
-                        autodiff(Reverse, $primals[1], Active, $dup_args...),
+                        autodiff(ReverseWithPrimal, $primals[1], Active, $dup_args...),
                         _,
                         evals = 1,
                     )


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I had deactivated the Enzyme results in the table which gets pasted into each PR when 1.11 was released, because there were some compat issues with Turing.jl. These seem to be resolved, so I'm re-enabling. Additionally, I'm now comparing with `ReverseWithValue`, rather than `Reverse`, because this is a like-for-like comparison with what the other frameworks are doing.