### PR TITLE
Make some functions not generated

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.60"
+version = "0.4.61"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1302,11 +1302,8 @@ straightforward to figure out much time is spent pushing to the block stack when
     return nothing
 end
 
-@generated function __make_tuples(::Type{T}, args::Tuple) where {T}
-    lazy_exprs = map(eachindex(T.parameters)) do n
-        return :(lazy_zero_rdata($(T.parameters[n]), primal(args[$n])))
-    end
-    return Expr(:call, tuple, lazy_exprs...)
+@inline function __make_tuples(::Type{T}, args::Tuple) where {T<:Tuple}
+    return map((T, arg) -> lazy_zero_rdata(T, primal(arg)), fieldtypes(T), args)
 end
 
 """

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -252,10 +252,10 @@ end
 Helper for [`reverse_data_ref_stmts`](@ref). Constructs a `Ref` whose element type is the
 [`zero_like_rdata_type`](@ref) for `P`, and whose element is the zero-like rdata for `P`.
 """
-@inline @generated function __make_ref(p::Type{P}) where {P}
+@inline function __make_ref(p::Type{P}) where {P}
     _P = @isdefined(P) ? P : _typeof(p)
     R = zero_like_rdata_type(_P)
-    return :(Ref{$R}(Mooncake.zero_like_rdata_from_type($_P)))
+    return Ref{R}(Mooncake.zero_like_rdata_from_type(_P))
 end
 
 # This specialised method is necessary to ensure that `__make_ref` works properly for

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -651,7 +651,7 @@ function rrule!!(
     end
 end
 
-@generated is_homogeneous_and_immutable(::P) where {P<:Tuple} = allequal(P.parameters)
+is_homogeneous_and_immutable(::P) where {P<:Tuple} = allequal(fieldtypes(P))
 @inline is_homogeneous_and_immutable(p::NamedTuple) = is_homogeneous_and_immutable(Tuple(p))
 is_homogeneous_and_immutable(::Any) = false
 

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -35,4 +35,4 @@ end
 struct SingletonStack{T} end
 
 Base.push!(::SingletonStack, ::Any) = nothing
-@generated Base.pop!(::SingletonStack{T}) where {T} = T.instance
+Base.pop!(::SingletonStack{T}) where {T} = T.instance


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Using a generated function when it's not needed is generally considered bad practice. While working on GPU stuff, I realised there are a few low-hanging generated functions that can be really easily replaced with regular functions.

This PR tries making this change. Semantically, nothing has changed. Hopefully, nothing has changed in performance terms either. If CI passes, this will get merged.