### PR TITLE
Replace _type with widenconst

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.65"
+version = "0.4.66"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -116,11 +116,13 @@ else
     get_inference_world(interp::CC.AbstractInterpreter) = CC.get_inference_world(interp)
 end
 
-_type(x::Type) = x
-_type(x::CC.Const) = _typeof(x.val)
-_type(x::CC.PartialStruct) = x.typ
-_type(x::CC.Conditional) = Union{_type(x.thentype),_type(x.elsetype)}
-_type(::CC.PartialTypeVar) = TypeVar
+_type(x) = CC.widenconst(x)
+
+# _type(x::Type) = x
+# _type(x::CC.Const) = _typeof(x.val)
+# _type(x::CC.PartialStruct) = x.typ
+# _type(x::CC.Conditional) = Union{_type(x.thentype),_type(x.elsetype)}
+# _type(::CC.PartialTypeVar) = TypeVar
 
 struct NoInlineCallInfo <: CC.CallInfo
     info::CC.CallInfo # wrapped call

--- a/src/interpreter/abstract_interpretation.jl
+++ b/src/interpreter/abstract_interpretation.jl
@@ -116,14 +116,6 @@ else
     get_inference_world(interp::CC.AbstractInterpreter) = CC.get_inference_world(interp)
 end
 
-_type(x) = CC.widenconst(x)
-
-# _type(x::Type) = x
-# _type(x::CC.Const) = _typeof(x.val)
-# _type(x::CC.PartialStruct) = x.typ
-# _type(x::CC.Conditional) = Union{_type(x.thentype),_type(x.elsetype)}
-# _type(::CC.PartialTypeVar) = TypeVar
-
 struct NoInlineCallInfo <: CC.CallInfo
     info::CC.CallInfo # wrapped call
     tt::Any # signature

--- a/src/interpreter/ir_normalisation.jl
+++ b/src/interpreter/ir_normalisation.jl
@@ -111,7 +111,7 @@ to be the return type given by the code cache.
 function fix_up_invoke_inference!(ir::IRCode)::IRCode
     stmts = ir.stmts
     for n in 1:length(stmts)
-        if Meta.isexpr(stmt(stmts)[n], :invoke) && _type(stmts.type[n]) == Any
+        if Meta.isexpr(stmt(stmts)[n], :invoke) && CC.widenconst(stmts.type[n]) == Any
             mi = stmt(stmts)[n].args[1]::Core.MethodInstance
             R = isdefined(mi, :cache) ? mi.cache.rettype : CC.return_type(mi.specTypes)
             stmts.type[n] = R

--- a/src/interpreter/ir_utils.jl
+++ b/src/interpreter/ir_utils.jl
@@ -128,7 +128,7 @@ end
 # https://gist.github.com/oxinabox/cdcffc1392f91a2f6d80b2524726d802#file-example-jl-L54
 function __get_toplevel_mi_from_ir(ir, _module::Module)
     mi = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ())
-    mi.specTypes = Tuple{map(_type, ir.argtypes)...}
+    mi.specTypes = Tuple{map(CC.widenconst, ir.argtypes)...}
     mi.def = _module
     return mi
 end

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -63,8 +63,7 @@ using Mooncake:
     verify_rdata_value,
     is_primitive,
     MinimalCtx,
-    stmt,
-    _type
+    stmt
 
 using .TestUtils:
     test_rule,

--- a/test/interpreter/abstract_interpretation.jl
+++ b/test/interpreter/abstract_interpretation.jl
@@ -70,8 +70,4 @@ contains_primitive_behind_call(x) = @inline contains_primitive(x)
             @test stmt(ad_ir.stmts)[invoke_line].args[2] == GlobalRef(Main, :a_primitive)
         end
     end
-    @testset "_type" begin
-        @test _type(CC.Const(5.0)) === Float64
-        @test _type(CC.PartialTypeVar(TypeVar(:a, Union{}, Any), true, true)) === TypeVar
-    end
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
In my adventures to make everything in #426 work properly, I discovered that the compiler has a function `Core.Compiler.widenconst`, which is almost exactly what my `Mooncake._type` function does.

This PR looks at replacing Mooncake's `_type` functionality` with `widenconst`, as this is obviously a better thing to do.

There's a slight discrepancy between how `CC.widentconst` and `Mooncake._type` handle `CC.Conditional`s, but I suspect my version is just wrong.

In this PR I've replaced the various methods of `_type` with a single method that just defers the call to `CC.widenconst`. This was the quickest way to make a PR and see if it works. If CI passes, I'll remove the `_type` function entirely, and replace all calls to `_type` with `widenconst` before merging.