### PR TITLE
Eliminate Rule Type Mismatch Errors Forever

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.66"
+version = "0.4.67"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -188,7 +188,13 @@ function ADInfo(
     zero_lazy_rdata_ref = Ref{Tlazy_rdata_ref}()
     return ADInfo(
         interp,
-        arg_types, ssa_insts, is_used_dict, debug_mode, zero_lazy_rdata_ref, fwd_ret_type, rvs_ret_type
+        arg_types,
+        ssa_insts,
+        is_used_dict,
+        debug_mode,
+        zero_lazy_rdata_ref,
+        fwd_ret_type,
+        rvs_ret_type,
     )
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -301,7 +301,7 @@ function opaque_closure(
     src = CC.ir_to_codeinf!(src, ir)
     return Base.Experimental.generate_opaque_closure(
         sig, Union{}, ret_type, src, nargs, isva, env...; do_compile
-    )::Core.OpaqueClosure{<:Tuple,ret_type}
+    )::Core.OpaqueClosure{sig,ret_type}
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -250,7 +250,8 @@ map_prod(f, xs...) = map(f, flat_product(xs...))
         @nospecialize env...;
         isva::Bool=false,
         do_compile::Bool=true,
-    )
+    )::Core.OpaqueClosure{<:Tuple, ret_type}
+
 Construct a `Core.OpaqueClosure`. Almost equivalent to
 `Core.OpaqueClosure(ir, env...; isva, do_compile)`, but instead of letting
 `Core.compute_oc_rettype` figure out the return type from `ir`, impose `ret_type` as the
@@ -300,7 +301,7 @@ function opaque_closure(
     src = CC.ir_to_codeinf!(src, ir)
     return Base.Experimental.generate_opaque_closure(
         sig, Union{}, ret_type, src, nargs, isva, env...; do_compile
-    )
+    )::Core.OpaqueClosure{<:Tuple,ret_type}
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -242,3 +242,85 @@ flat_product(xs...) = vec(collect(Iterators.product(xs...)))
 Equivalent to `map(f, flat_product(xs...))`.
 """
 map_prod(f, xs...) = map(f, flat_product(xs...))
+
+"""
+    opaque_closure(
+        ret_type::Type,
+        ir::IRCode,
+        @nospecialize env...;
+        isva::Bool=false,
+        do_compile::Bool=true,
+    )
+Construct a `Core.OpaqueClosure`. Almost equivalent to
+`Core.OpaqueClosure(ir, env...; isva, do_compile)`, but instead of letting
+`Core.compute_oc_rettype` figure out the return type from `ir`, impose `ret_type` as the
+return type.
+
+# Warning
+
+User beware: if the `Core.OpaqueClosure` produced by this function ever returns anything
+which is not an instance of a subtype of `ret_type`, you should expect all kinds of awful
+things to happen, such as segfaults. You have been warned!
+
+# Extended Help
+
+This is needed in Mooncake.jl because make extensive use of our ability to know the return
+type of a couple of specific `OpaqueClosure`s without actually having constructed them --
+see `LazyDerivedRule`. Without the capability to specify the return type, we have to guess
+what type `compute_ir_rettype` will return for a given `IRCode` before we have constructed
+the `IRCode` and run type inference on it. This exposes us to details of type inference,
+which are not part of the public interface of the language, and can therefore vary from
+Julia version to Julia version (including patch versions). Moreover, even for a fixed Julia
+version it can be extremely hard to predict exactly what type inference will infer to be the
+return type of a function.
+
+Failing to correctly guess the return type can happen for a number of reasons, and the kinds
+of errors that tend to be generated when this fails tell you very little about the
+underlying cause of the problem.
+
+By specifying the return type ourselves, we remove this dependence. The price we pay for
+this is the potential for segfaults etc if we fail to specify `ret_type` correctly.
+"""
+function opaque_closure(
+    ret_type::Type,
+    ir::IRCode,
+    @nospecialize env...;
+    isva::Bool=false,
+    do_compile::Bool=true,
+)
+    # This implementation is copied over directly from `Core.OpaqueClosure`.
+    ir = CC.copy(ir)
+    nargs = length(ir.argtypes) - 1
+    sig = Base.Experimental.compute_oc_signature(ir, nargs, isva)
+    src = ccall(:jl_new_code_info_uninit, Ref{CC.CodeInfo}, ())
+    src.slotnames = fill(:none, nargs + 1)
+    src.slotflags = fill(zero(UInt8), length(ir.argtypes))
+    src.slottypes = copy(ir.argtypes)
+    src.rettype = ret_type
+    src = CC.ir_to_codeinf!(src, ir)
+    return Base.Experimental.generate_opaque_closure(
+        sig, Union{}, ret_type, src, nargs, isva, env...; do_compile
+    )
+end
+
+"""
+    misty_closure(
+        ret_type::Type,
+        ir::IRCode,
+        @nospecialize env...;
+        isva::Bool=false,
+        do_compile::Bool=true,
+    )
+
+Identical to [`Mooncake.opaque_closure`](@ref), but returns a `MistyClosure` closure rather
+than a `Core.OpaqueClosure`.
+"""
+function misty_closure(
+    ret_type::Type,
+    ir::IRCode,
+    @nospecialize env...;
+    isva::Bool=false,
+    do_compile::Bool=true,
+)
+    return MistyClosure(opaque_closure(ret_type, ir, env...; isva, do_compile), Ref(ir))
+end

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -33,7 +33,14 @@ end
         is_used_dict = Dict{ID,Bool}(id_ssa_1 => true, id_ssa_2 => true)
         rdata_ref = Ref{Tuple{map(Mooncake.lazy_zero_rdata_type, (Float64, Int))...}}()
         info = ADInfo(
-            get_interpreter(), arg_types, ssa_insts, is_used_dict, false, rdata_ref, Any, Any
+            get_interpreter(),
+            arg_types,
+            ssa_insts,
+            is_used_dict,
+            false,
+            rdata_ref,
+            Any,
+            Any,
         )
 
         # Verify that we can access the interpreter and terminator block ID.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -84,4 +84,23 @@
         @test Mooncake.is_always_fully_initialised(TestResources.Foo)
         @test !Mooncake.is_always_fully_initialised(TestResources.StructFoo)
     end
+    @testset "opaque_closure" begin
+
+        # Get the IRCode for `sin` applied to a `Float64`.
+        ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64})[1][1]
+
+        # Check that regular OpaqueClosure construction works as expected.
+        oc = Mooncake.opaque_closure(Float64, ir)
+        @test oc isa Core.OpaqueClosure{Tuple{Float64}, Float64}
+        @test oc(5.0) == sin(5.0)
+
+        # Construct the same OpaqueClosure, but tell it what the type is.
+        oc2 = Mooncake.opaque_closure(Any, ir)
+        @test oc2 isa Core.OpaqueClosure{Tuple{Float64}, Any}
+        @test oc2(5.0) == sin(5.0)
+
+        # Check that we can get a MistyClosure also.
+        mc = Mooncake.misty_closure(Float64, ir)
+        @test mc(5.0) == sin(5.0)
+    end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -84,7 +84,7 @@
         @test Mooncake.is_always_fully_initialised(TestResources.Foo)
         @test !Mooncake.is_always_fully_initialised(TestResources.StructFoo)
     end
-    @testset "opaque_closure" begin
+    @testset "opaque_closure and misty_closure" begin
 
         # Get the IRCode for `sin` applied to a `Float64`.
         ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64})[1][1]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -87,16 +87,16 @@
     @testset "opaque_closure and misty_closure" begin
 
         # Get the IRCode for `sin` applied to a `Float64`.
-        ir = Base.code_ircode_by_type(Tuple{typeof(sin), Float64})[1][1]
+        ir = Base.code_ircode_by_type(Tuple{typeof(sin),Float64})[1][1]
 
         # Check that regular OpaqueClosure construction works as expected.
         oc = Mooncake.opaque_closure(Float64, ir)
-        @test oc isa Core.OpaqueClosure{Tuple{Float64}, Float64}
+        @test oc isa Core.OpaqueClosure{Tuple{Float64},Float64}
         @test oc(5.0) == sin(5.0)
 
         # Construct the same OpaqueClosure, but tell it what the type is.
         oc2 = Mooncake.opaque_closure(Any, ir)
-        @test oc2 isa Core.OpaqueClosure{Tuple{Float64}, Any}
+        @test oc2 isa Core.OpaqueClosure{Tuple{Float64},Any}
         @test oc2(5.0) == sin(5.0)
 
         # Check that we can get a MistyClosure also.


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
A really annoying class of errors is handled here: https://github.com/compintell/Mooncake.jl/blob/8c478a88bbd89d12507441314f21fb193e4eceef/src/interpreter/s2s_reverse_mode_ad.jl#L1726

This error occurs because we have to guess what type inference is going infer the return for the forwards-pass IR to be, based on the primal IR (its argument types and return type). We are able to correctly guess this type the vast majority of the time on correctly derived code -- we only occasionally runs into problems when inference does quite special things for e.g. small unions of `Tuple`s. However, this is a loosing battle -- see the docstring for the new `opaque_closure` function for more details.

The bigger problem is this: when something goes wrong when deriving a rule we often see this error, rather than the code running until we hit the actual error which caused the problem. This is bad for both developers and users, because this error is almost never the root cause of a problem (I can't remember the last time it was). Instead, we have to do some detective work to figure out where the actual problem lies. I find this hard, so it will be extremely challenging for a new user.

Now, unless something has gone badly wrong, it's never the case that the type we guess for the return type is invalid, it's just that we guess a different type to the one that inference returns. A recent example of this I encountered involved us guessing that inference would return `Tuple{Union{A, B}, C}` when in fact it returned `Union{Tuple{A, C}, Tuple{B, C}}` (or something along those lines). In this case, the collection of concrete types which subtype these types is the same, so either is fine. Which one inference winds up picking is essentially an implementation detail, and (could) change between Julia versions. (I'm quite certain that this is just the tip of the iceberg in terms of weird edge cases that could cause trouble. Moreover, when this kind of thing goes wrong, it takes me at least a day to figure out what happened and how a fix might work.) It's never the case (modulo bugs) that we say that a function returns `AbstractFloat` when in fact it can return an `Int`.

To solve this problem, I've changed things so that in addition to specifying the argument types + IR for the OpaqueClosures we construct to perform the forwards- and reverse-passes, we specify the return type (previously the return type was derived from the IR + argtypes). This requires a helper function that is basically a tweaked version of some code from `Base.Experimental`. The win is that we get to specify the return type ourselves, so we can just be consistent about it, thereby completely eliminating the class of error described above. We shall never see it again.

The downside of this approach is of course that, if we have a bug and specify an upper bound on the return type of an `OpaqueClosure` we construct which is not in fact a valid upper bound, I imagine that all sorts of terrible things (e.g. segfaults) will happen. To guard against this, I've inserted `typeassert` statements into the IR that AD generates immediately before all `ReturnNode`s on both the forwards- and reverse-passes of AD. This should guard against accidentally returning bad data.

The motivation for dealing with this now is errors I've been encountering in #426 -- I'm really hoping this makes debugging them much more straightforward.

edit: this error has been causing me trouble for almost a year at this point, so I'm very excited to be rid of it.