### PR TITLE
Docstring Formatting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.70"
+version = "0.4.71"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -396,15 +396,15 @@ fields_type(::Type{RData{T}}) where {T<:NamedTuple} = T
     return RData(increment_field!!(x.data, new_val, Val(f)))
 end
 
-@doc """
-     rdata_type(T)
+"""
+    rdata_type(T)
 
- Returns the type of the reverse data of a tangent of type T.
+Returns the type of the reverse data of a tangent of type T.
 
- # Extended help
+# Extended help
 
- See extended help in [`fdata_type`](@ref) docstring.
- """
+See extended help in [`fdata_type`](@ref) docstring.
+"""
 rdata_type(T)
 
 rdata_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -565,65 +565,65 @@ end
 
 __get_primals(xs) = map(x -> x isa CoDual ? primal(x) : x, xs)
 
-@doc """
-     test_rule(
-         rng, x...;
-         interface_only=false,
-         is_primitive::Bool=true,
-         perf_flag::Symbol=:none,
-         interp::Mooncake.MooncakeInterpreter=Mooncake.get_interpreter(),
-         debug_mode::Bool=false,
-         unsafe_perturb::Bool=false,
-     )
+"""
+    test_rule(
+        rng, x...;
+        interface_only=false,
+        is_primitive::Bool=true,
+        perf_flag::Symbol=:none,
+        interp::Mooncake.MooncakeInterpreter=Mooncake.get_interpreter(),
+        debug_mode::Bool=false,
+        unsafe_perturb::Bool=false,
+    )
 
- Run standardised tests on the `rule` for `x`.
- The first element of `x` should be the primal function to test, and each other element a
- positional argument.
- In most cases, elements of `x` can just be the primal values, and `randn_tangent` can be
- relied upon to generate an appropriate tangent to test. Some notable exceptions exist
- though, in partcular `Ptr`s. In this case, the argument for which `randn_tangent` cannot be
- readily defined should be a `CoDual` containing the primal, and a _manually_ constructed
- tangent field.
+Run standardised tests on the `rule` for `x`.
+The first element of `x` should be the primal function to test, and each other element a
+positional argument.
+In most cases, elements of `x` can just be the primal values, and `randn_tangent` can be
+relied upon to generate an appropriate tangent to test. Some notable exceptions exist
+though, in partcular `Ptr`s. In this case, the argument for which `randn_tangent` cannot be
+readily defined should be a `CoDual` containing the primal, and a _manually_ constructed
+tangent field.
 
- This function uses [`Mooncake.build_rrule`](@ref) to construct a rule. This will use an
- `rrule!!` if one exists, and derive a rule otherwise.
+This function uses [`Mooncake.build_rrule`](@ref) to construct a rule. This will use an
+`rrule!!` if one exists, and derive a rule otherwise.
 
- # Arguments
- - `rng::AbstractRNG`: a random number generator
- - `x...`: the function (first element) and its arguments (the remainder)
+# Arguments
+- `rng::AbstractRNG`: a random number generator
+- `x...`: the function (first element) and its arguments (the remainder)
 
- # Keyword Arguments
- - `interface_only::Bool=false`: test only that the interface is satisfied, without testing
-     correctness. This should generally be set to `false` (the default value), and only
-     enabled if the testing infrastructure is unable to test correctness for some reason
-     e.g. the returned value of the function is a `Ptr`, and appropriate tangents cannot,
-     therefore, be generated for it automatically.
- - `is_primitive::Bool=true`: check whether the thing that you are testing has a hand-written
-     `rrule!!`. This option is helpful if you are testing a new `rrule!!`, as it enables you
-     to verify that your method of `is_primitive` has returned the correct value, and that
-     you are actually testing a method of the `rrule!!` function -- a common mistake when
-     authoring a new `rrule!!` is to implement `is_primitive` incorrectly and to accidentally
-     wind up testing a rule which Mooncake has derived, as opposed to the one that you have
-     written. If you are testing something for which you have not
-     hand-written an `rrule!!`, or which you do not care whether it has a hand-written
-     `rrule!!` or not, you should set it to `false`.
- - `perf_flag::Symbol=:none`: the value of this symbol determines what kind of performance
-     tests should be performed. By default, none are performed. If you believe that a rule
-     should be allocation-free (iff the primal is allocation free), set this to `:allocs`. If
-     you hand-write an `rrule!!` and believe that your test case should be type stable, set
-     this to `:stability` (at present we cannot verify whether a derived rule is type stable
-     for technical reasons). If you believe that a hand-written rule should be _both_
-     allocation-free and type-stable, set this to `:stability_and_allocs`.
- - `interp::Mooncake.MooncakeInterpreter=Mooncake.get_interpreter()`: the abstract
-     interpreter to be used when testing this rule. The default should generally be used.
- - `debug_mode::Bool=false`: whether or not the rule should be tested in debug mode.
-     Typically this should be left at its default `false` value, but if you are finding that
-     the tests are failing for a given rule, you may wish to temporarily set it to `true` in
-     order to get access to additional information and automated testing.
- - `unsafe_perturb::Bool=false`: value passed as the third argument to `_add_to_primal`.
-     Should usually be left `false` -- consult the docstring for `_add_to_primal` for more
-     info on when you might wish to set it to `true`.
- """
+# Keyword Arguments
+- `interface_only::Bool=false`: test only that the interface is satisfied, without testing
+    correctness. This should generally be set to `false` (the default value), and only
+    enabled if the testing infrastructure is unable to test correctness for some reason
+    e.g. the returned value of the function is a `Ptr`, and appropriate tangents cannot,
+    therefore, be generated for it automatically.
+- `is_primitive::Bool=true`: check whether the thing that you are testing has a hand-written
+    `rrule!!`. This option is helpful if you are testing a new `rrule!!`, as it enables you
+    to verify that your method of `is_primitive` has returned the correct value, and that
+    you are actually testing a method of the `rrule!!` function -- a common mistake when
+    authoring a new `rrule!!` is to implement `is_primitive` incorrectly and to accidentally
+    wind up testing a rule which Mooncake has derived, as opposed to the one that you have
+    written. If you are testing something for which you have not
+    hand-written an `rrule!!`, or which you do not care whether it has a hand-written
+    `rrule!!` or not, you should set it to `false`.
+- `perf_flag::Symbol=:none`: the value of this symbol determines what kind of performance
+    tests should be performed. By default, none are performed. If you believe that a rule
+    should be allocation-free (iff the primal is allocation free), set this to `:allocs`. If
+    you hand-write an `rrule!!` and believe that your test case should be type stable, set
+    this to `:stability` (at present we cannot verify whether a derived rule is type stable
+    for technical reasons). If you believe that a hand-written rule should be _both_
+    allocation-free and type-stable, set this to `:stability_and_allocs`.
+- `interp::Mooncake.MooncakeInterpreter=Mooncake.get_interpreter()`: the abstract
+    interpreter to be used when testing this rule. The default should generally be used.
+- `debug_mode::Bool=false`: whether or not the rule should be tested in debug mode.
+    Typically this should be left at its default `false` value, but if you are finding that
+    the tests are failing for a given rule, you may wish to temporarily set it to `true` in
+    order to get access to additional information and automated testing.
+- `unsafe_perturb::Bool=false`: value passed as the third argument to `_add_to_primal`.
+    Should usually be left `false` -- consult the docstring for `_add_to_primal` for more
+    info on when you might wish to set it to `true`.
+"""
 function test_rule(
     rng::AbstractRNG,
     x...;
@@ -1077,18 +1077,18 @@ function __is_completely_stable_type(::Type{P}) where {P}
     return all(__is_completely_stable_type, fieldtypes(P))
 end
 
-@doc """
-     test_tangent(rng::AbstractRNG, p::P, x::T, y::T, z_target::T) where {P, T}
+"""
+    test_tangent(rng::AbstractRNG, p::P, x::T, y::T, z_target::T) where {P, T}
 
- Verify that primal `p` with tangents `z_target`, `x`, and `y`, satisfies the tangent
- interface. If these tests pass, then it should be possible to write rules for primals
- of type `P`, and to test them using [`test_rule`](@ref).
+Verify that primal `p` with tangents `z_target`, `x`, and `y`, satisfies the tangent
+interface. If these tests pass, then it should be possible to write rules for primals
+of type `P`, and to test them using [`test_rule`](@ref).
 
- It should be the case that `z_target` == `increment!!(x, y)`.
+It should be the case that `z_target` == `increment!!(x, y)`.
 
- As always, there are limits to the errors that these tests can identify -- they form
- necessary but not sufficient conditions for the correctness of your code.
- """
+As always, there are limits to the errors that these tests can identify -- they form
+necessary but not sufficient conditions for the correctness of your code.
+"""
 function test_tangent(
     rng::AbstractRNG, p::P, x::T, y::T, z_target::T; interface_only, perf=true
 ) where {P,T}

--- a/src/tools_for_rules.jl
+++ b/src/tools_for_rules.jl
@@ -254,30 +254,30 @@ function increment_and_get_rdata!(f, r, t::CRC.Thunk)
     return increment_and_get_rdata!(f, r, CRC.unthunk(t))
 end
 
-@doc """
-     rrule_wrapper(f::CoDual, args::CoDual...)
+"""
+    rrule_wrapper(f::CoDual, args::CoDual...)
 
- Used to implement `rrule!!`s via `ChainRulesCore.rrule`.
+Used to implement `rrule!!`s via `ChainRulesCore.rrule`.
 
- Given a function `foo`, argument types `arg_types`, and a method of `ChainRulesCore.rrule`
- which applies to these, you can make use of this function as follows:
- ```julia
- Mooncake.@is_primitive DefaultCtx Tuple{typeof(foo), arg_types...}
- function Mooncake.rrule!!(f::CoDual{typeof(foo)}, args::CoDual...)
-     return rrule_wrapper(f, args...)
- end
- ```
- Assumes that methods of `to_cr_tangent` and `to_mooncake_tangent` are defined such that you
- can convert between the different representations of tangents that Mooncake and
- ChainRulesCore expect.
+Given a function `foo`, argument types `arg_types`, and a method of `ChainRulesCore.rrule`
+which applies to these, you can make use of this function as follows:
+```julia
+Mooncake.@is_primitive DefaultCtx Tuple{typeof(foo), arg_types...}
+function Mooncake.rrule!!(f::CoDual{typeof(foo)}, args::CoDual...)
+    return rrule_wrapper(f, args...)
+end
+```
+Assumes that methods of `to_cr_tangent` and `to_mooncake_tangent` are defined such that you
+can convert between the different representations of tangents that Mooncake and
+ChainRulesCore expect.
 
- Furthermore, it is _essential_ that
- 1. `f(args)` does not mutate `f` or `args`, and
- 2. the result of `f(args)` does not alias any data stored in `f` or `args`.
+Furthermore, it is _essential_ that
+1. `f(args)` does not mutate `f` or `args`, and
+2. the result of `f(args)` does not alias any data stored in `f` or `args`.
 
- Subject to some constraints, you can use the [`@from_rrule`](@ref) macro to reduce the
- amount of boilerplate code that you are required to write even further.
- """
+Subject to some constraints, you can use the [`@from_rrule`](@ref) macro to reduce the
+amount of boilerplate code that you are required to write even further.
+"""
 function rrule_wrapper(fargs::Vararg{CoDual,N}) where {N}
 
     # Run forwards-pass.
@@ -333,119 +333,119 @@ function construct_rrule_wrapper_def(arg_names, arg_types, where_params)
     return construct_def(arg_names, arg_types, where_params, body)
 end
 
-@doc """
-     @from_rrule ctx sig [has_kwargs=false]
+"""
+    @from_rrule ctx sig [has_kwargs=false]
 
- Convenience functionality to assist in using `ChainRulesCore.rrule`s to write `rrule!!`s.
+Convenience functionality to assist in using `ChainRulesCore.rrule`s to write `rrule!!`s.
 
- # Arguments
+# Arguments
 
- - `ctx`: A Mooncake context type
- - `sig`: the signature which you wish to assert should be a primitive in `Mooncake.jl`, and
-     use an existing `ChainRulesCore.rrule` to implement this functionality.
- - `has_kwargs`: a `Bool` state whether or not the function has keyword arguments. This
-     feature has the same limitations as `ChainRulesCore.rrule` -- the derivative w.r.t. all
-     kwargs must be zero.
+- `ctx`: A Mooncake context type
+- `sig`: the signature which you wish to assert should be a primitive in `Mooncake.jl`, and
+    use an existing `ChainRulesCore.rrule` to implement this functionality.
+- `has_kwargs`: a `Bool` state whether or not the function has keyword arguments. This
+    feature has the same limitations as `ChainRulesCore.rrule` -- the derivative w.r.t. all
+    kwargs must be zero.
 
- # Example Usage
+# Example Usage
 
- ## A Basic Example
+## A Basic Example
 
- ```jldoctest
- julia> using Mooncake: @from_rrule, DefaultCtx, rrule!!, zero_fcodual, TestUtils
+```jldoctest
+julia> using Mooncake: @from_rrule, DefaultCtx, rrule!!, zero_fcodual, TestUtils
 
- julia> using ChainRulesCore
+julia> using ChainRulesCore
 
- julia> foo(x::Real) = 5x;
+julia> foo(x::Real) = 5x;
 
- julia> function ChainRulesCore.rrule(::typeof(foo), x::Real)
-            foo_pb(Ω::Real) = ChainRulesCore.NoTangent(), 5Ω
-            return foo(x), foo_pb
-        end;
+julia> function ChainRulesCore.rrule(::typeof(foo), x::Real)
+        foo_pb(Ω::Real) = ChainRulesCore.NoTangent(), 5Ω
+        return foo(x), foo_pb
+    end;
 
- julia> @from_rrule DefaultCtx Tuple{typeof(foo), Base.IEEEFloat}
+julia> @from_rrule DefaultCtx Tuple{typeof(foo), Base.IEEEFloat}
 
- julia> rrule!!(zero_fcodual(foo), zero_fcodual(5.0))[2](1.0)
- (NoRData(), 5.0)
+julia> rrule!!(zero_fcodual(foo), zero_fcodual(5.0))[2](1.0)
+(NoRData(), 5.0)
 
- julia> # Check that the rule works as intended.
-        TestUtils.test_rule(Xoshiro(123), foo, 5.0; is_primitive=true)
- Test Passed
- ```
+julia> # Check that the rule works as intended.
+    TestUtils.test_rule(Xoshiro(123), foo, 5.0; is_primitive=true)
+Test Passed
+```
 
- ## An Example with Keyword Arguments
+## An Example with Keyword Arguments
 
- ```jldoctest
- julia> using Mooncake: @from_rrule, DefaultCtx, rrule!!, zero_fcodual, TestUtils
+```jldoctest
+julia> using Mooncake: @from_rrule, DefaultCtx, rrule!!, zero_fcodual, TestUtils
 
- julia> using ChainRulesCore
+julia> using ChainRulesCore
 
- julia> foo(x::Real; cond::Bool) = cond ? 5x : 4x;
+julia> foo(x::Real; cond::Bool) = cond ? 5x : 4x;
 
- julia> function ChainRulesCore.rrule(::typeof(foo), x::Real; cond::Bool)
-            foo_pb(Ω::Real) = ChainRulesCore.NoTangent(), cond ? 5Ω : 4Ω
-            return foo(x; cond), foo_pb
-        end;
+julia> function ChainRulesCore.rrule(::typeof(foo), x::Real; cond::Bool)
+        foo_pb(Ω::Real) = ChainRulesCore.NoTangent(), cond ? 5Ω : 4Ω
+        return foo(x; cond), foo_pb
+    end;
 
- julia> @from_rrule DefaultCtx Tuple{typeof(foo), Base.IEEEFloat} true
+julia> @from_rrule DefaultCtx Tuple{typeof(foo), Base.IEEEFloat} true
 
- julia> _, pb = rrule!!(
-            zero_fcodual(Core.kwcall),
-            zero_fcodual((cond=false, )),
-            zero_fcodual(foo),
-            zero_fcodual(5.0),
-        );
+julia> _, pb = rrule!!(
+        zero_fcodual(Core.kwcall),
+        zero_fcodual((cond=false, )),
+        zero_fcodual(foo),
+        zero_fcodual(5.0),
+    );
 
- julia> pb(3.0)
- (NoRData(), NoRData(), NoRData(), 12.0)
+julia> pb(3.0)
+(NoRData(), NoRData(), NoRData(), 12.0)
 
- julia> # Check that the rule works as intended.
-        TestUtils.test_rule(
-            Xoshiro(123), Core.kwcall, (cond=false, ), foo, 5.0; is_primitive=true
-        )
- Test Passed
- ```
- Notice that, in order to access the kwarg method we must call the method of `Core.kwcall`,
- as Mooncake's `rrule!!` does not itself permit the use of kwargs.
+julia> # Check that the rule works as intended.
+    TestUtils.test_rule(
+        Xoshiro(123), Core.kwcall, (cond=false, ), foo, 5.0; is_primitive=true
+    )
+Test Passed
+```
+Notice that, in order to access the kwarg method we must call the method of `Core.kwcall`,
+as Mooncake's `rrule!!` does not itself permit the use of kwargs.
 
- # Limitations
+# Limitations
 
- It is your responsibility to ensure that
- 1. calls with signature `sig` do not mutate their arguments,
- 2. the output of calls with signature `sig` does not alias any of the inputs.
+It is your responsibility to ensure that
+1. calls with signature `sig` do not mutate their arguments,
+2. the output of calls with signature `sig` does not alias any of the inputs.
 
- As with all hand-written rules, you should definitely make use of
- [`TestUtils.test_rule`](@ref) to verify correctness on some test cases.
+As with all hand-written rules, you should definitely make use of
+[`TestUtils.test_rule`](@ref) to verify correctness on some test cases.
 
- # Argument Type Constraints
+# Argument Type Constraints
 
- Many methods of `ChainRuleCore.rrule` are implemented with very loose type constraints.
- For example, it would not be surprising to see a method of rrule with the signature
- ```julia
- Tuple{typeof(rrule), typeof(foo), Real, AbstractVector{<:Real}}
- ```
- There are a variety of reasons for this way of doing things, and whether it is a good idea
- to write rules for such generic objects has been debated at length.
+Many methods of `ChainRuleCore.rrule` are implemented with very loose type constraints.
+For example, it would not be surprising to see a method of rrule with the signature
+```julia
+Tuple{typeof(rrule), typeof(foo), Real, AbstractVector{<:Real}}
+```
+There are a variety of reasons for this way of doing things, and whether it is a good idea
+to write rules for such generic objects has been debated at length.
 
- Suffice it to say, you should not write rules for _this_ package which are so generically
- typed.
- Rather, you should create rules for the subset of types for which you believe that the
- `ChainRulesCore.rrule` will work correctly, and leave this package to derive rules for the
- rest.
- For example, it is quite common to be confident that a given rule will work correctly for
- any `Base.IEEEFloat` argument, i.e. `Union{Float16, Float32, Float64}`, but it is usually
- not possible to know that the rule is correct for all possible subtypes of `Real` that
- someone might define.
+Suffice it to say, you should not write rules for _this_ package which are so generically
+typed.
+Rather, you should create rules for the subset of types for which you believe that the
+`ChainRulesCore.rrule` will work correctly, and leave this package to derive rules for the
+rest.
+For example, it is quite common to be confident that a given rule will work correctly for
+any `Base.IEEEFloat` argument, i.e. `Union{Float16, Float32, Float64}`, but it is usually
+not possible to know that the rule is correct for all possible subtypes of `Real` that
+someone might define.
 
- # Conversions Between Different Tangent Type Systems
+# Conversions Between Different Tangent Type Systems
 
- Under the hood, this functionality relies on two functions: `Mooncake.to_cr_tangent`, and
- `Mooncake.increment_and_get_rdata!`. These two functions handle conversion to / from
- `Mooncake` tangent types and `ChainRulesCore` tangent types. This functionality is known to
- work well for simple types, but has not been tested to a great extent on complicated
- composite types. If `@from_rrule` does not work in your case because the required method of
- either of these functions does not exist, please open an issue.
- """
+Under the hood, this functionality relies on two functions: `Mooncake.to_cr_tangent`, and
+`Mooncake.increment_and_get_rdata!`. These two functions handle conversion to / from
+`Mooncake` tangent types and `ChainRulesCore` tangent types. This functionality is known to
+work well for simple types, but has not been tested to a great extent on complicated
+composite types. If `@from_rrule` does not work in your case because the required method of
+either of these functions does not exist, please open an issue.
+"""
 macro from_rrule(ctx, sig::Expr, has_kwargs::Bool=false)
     arg_type_syms, where_params = parse_signature_expr(sig)
     arg_names = map(n -> Symbol("x_$n"), eachindex(arg_type_syms))


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
While working on GPU rules, I noticed there are still a few unnecessary `@doc` macro calls in front of docstrings. These cause weird formatting behaviour, so they're worth getting rid of to improve codebase hygiene.