### PR TITLE
Performance Robustness in Reverse Pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.75"
+version = "0.4.76"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -662,14 +662,11 @@ with.
     if P isa DataType
         names = fieldnames(P)
         types = fieldtypes(P)
-        wrapped_field_zeros = map(enumerate(tangent_field_types(P))) do (n, tt)
+        wrapped_field_zeros = map(enumerate(always_initialised(P))) do (n, init)
             fzero = :(zero_rdata_from_type($(types[n])))
-            if tt <: PossiblyUninitTangent
-                Q = :(rdata_type(tangent_type($(fieldtype(P, n)))))
-                return :(PossiblyUninitTangent{$Q}($fzero))
-            else
-                return fzero
-            end
+            init && return fzero
+            Q = :(rdata_type(tangent_type($(fieldtype(P, n)))))
+            return :(PossiblyUninitTangent{$Q}($fzero))
         end
         wrapped_field_zeros_tuple = Expr(:call, :tuple, wrapped_field_zeros...)
         wrapped_expr = :(R(NamedTuple{$names}($wrapped_field_zeros_tuple)))

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -405,7 +405,7 @@ function make_ad_stmts!(stmt::ReturnNode, line::ID, info::ADInfo)
     end
     if is_active(stmt.val)
         rdata_id = get_rev_data_id(info, stmt.val)
-        rvs = new_inst(Expr(:call, increment_ref!, rdata_id, Argument(2)))
+        rvs = increment_ref_stmts(rdata_id, Argument(2))
         assert_id = ID()
         val = __inc(stmt.val)
         fwds = [
@@ -819,12 +819,12 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
 end
 
 """
-    increment_ref_stmts(ref_id::ID, inc_data_id::ID)::Vector{IDInstPair}
+    increment_ref_stmts(ref_id::ID, inc_data)::Vector{IDInstPair}
 
 Equivalent to `ref[] = increment!!(ref[], inc_data)`, where `ref` and `inc_data` are the
 values associated to `ref_id` and `inc_data` respectively.
 """
-function increment_ref_stmts(ref_id::ID, inc_data_id::ID)::Vector{IDInstPair}
+function increment_ref_stmts(ref_id::ID, inc_data)::Vector{IDInstPair}
 
     # Get the value stored in the `Base.RefValue`.
     ref_val_id = ID()
@@ -832,7 +832,7 @@ function increment_ref_stmts(ref_id::ID, inc_data_id::ID)::Vector{IDInstPair}
 
     # Increment the value by inc_data.
     new_val_id = ID()
-    new_val = (new_val_id, new_inst(Expr(:call, increment!!, ref_val_id, inc_data_id)))
+    new_val = (new_val_id, new_inst(Expr(:call, increment!!, ref_val_id, inc_data)))
 
     # Update the value stored in the rdata reference.
     set_ref_expr = Expr(:call, setfield!, ref_id, QuoteNode(:x), new_val_id)

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1583,14 +1583,9 @@ ref[] = zero_rdata_from_type(P)
 ```
 """
 function deref_and_zero_stmts(P, ref_id, val_id)
-
-    # Get value from output_rdata.
     val = (val_id, new_inst(Expr(:call, getfield, ref_id, QuoteNode(:x))))
-
-    # Zero-out output_rdata_ref.
     r = Mooncake.zero_like_rdata_from_type(P)
     set_ref = (ID(), new_inst(Expr(:call, setfield!, ref_id, QuoteNode(:x), r)))
-
     return IDInstPair[val, set_ref]
 end
 

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1573,6 +1573,15 @@ function __get_value(edge::ID, x::IDPhiNode)
     return isassigned(x.values, n) ? x.values[n] : nothing
 end
 
+"""
+    deref_and_zero_stmts(P, ref_id, val_id)
+
+Equivalent to something like
+```julia
+val = ref[]
+ref[] = zero_rdata_from_type(P)
+```
+"""
 function deref_and_zero_stmts(P, ref_id, val_id)
 
     # Get value from output_rdata.

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -509,11 +509,6 @@ function make_ad_stmts!(stmt::PiNode, line::ID, info::ADInfo)
     return ad_stmt_info(line, nothing, fwds, rvs)
 end
 
-@inline function __pi_rvs!(::Type{P}, val_rdata_ref::Ref, output_rdata_ref::Ref) where {P}
-    increment_ref!(val_rdata_ref, __deref_and_zero(P, output_rdata_ref))
-    return nothing
-end
-
 # Constant GlobalRefs are handled. See const_codual. Non-constant GlobalRefs are handled by
 # assuming that they are constant, and creating a CoDual with the value. We then check at
 # run-time that the value has not changed.
@@ -880,8 +875,6 @@ end
 
 __get_primal(x::CoDual) = primal(x)
 __get_primal(x) = x
-
-@inline increment_ref!(x::Ref, t) = setindex!(x, increment!!(x[], t))
 
 const RuleMC{A,R} = MistyClosure{OpaqueClosure{A,R}}
 

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -881,10 +881,6 @@ end
 __get_primal(x::CoDual) = primal(x)
 __get_primal(x) = x
 
-@inline increment_if_ref!(ref::Ref, rvs_data) = increment_ref!(ref, rvs_data)
-@inline increment_if_ref!(::Ref, ::ZeroRData) = nothing
-@inline increment_if_ref!(::Nothing, ::Any) = nothing
-
 @inline increment_ref!(x::Ref, t) = setindex!(x, increment!!(x[], t))
 
 const RuleMC{A,R} = MistyClosure{OpaqueClosure{A,R}}

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1437,7 +1437,7 @@ function pullback_ir(
 
         # De-reference the nth rdata.
         rdata_id = ID()
-        rdata = new_inst(Expr(:call, getindex, arg_rdata_ref_ids[n]))
+        rdata = new_inst(Expr(:call, getfield, arg_rdata_ref_ids[n], QuoteNode(:x)))
 
         # Get the nth lazy zero rdata.
         lazy_zero_rdata_id = ID()

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -761,21 +761,6 @@ function make_ad_stmts!(stmt::Expr, line::ID, info::ADInfo)
 
                 # Construct statments to increment ref.
                 return vcat(rdata_inc, increment_ref_stmts(rev_data_id, rdata_inc_id))
-
-                # # Dereference the current rdata value.
-                # rdata_id = ID()
-                # rdata = (rdata_id, new_inst(Expr(:call, getfield, rev_data_id, QuoteNode(:x))))
-
-                # # Increment the rdata by the new rdata value returned by call_pullback.
-                # new_rdata_id = ID()
-                # new_rdata_expr = Expr(:call, increment!!, rdata_id, rdata_inc_id)
-                # new_rdata = (new_rdata_id, new_inst(new_rdata_expr))
-
-                # # Update the value stored in the rdata reference.
-                # set_rdata_ref_expr = Expr(:call, setfield!, rev_data_id, QuoteNode(:x), new_rdata_id)
-                # set_rdata_ref = (ID(), new_inst(set_rdata_ref_expr))
-
-                # return [rdata, rdata_inc, new_rdata, set_rdata_ref]
             end
 
             # Concatenate all statements, and return them.

--- a/src/interpreter/zero_like_rdata.jl
+++ b/src/interpreter/zero_like_rdata.jl
@@ -11,6 +11,8 @@ error -- please open an issue in such a situation.
 struct ZeroRData end
 
 @inline increment!!(::ZeroRData, r::R) where {R} = r
+@inline increment!!(r::R, ::ZeroRData) where {R} = r
+@inline increment!!(::ZeroRData, ::ZeroRData) = ZeroRData()
 
 """
     zero_like_rdata_type(::Type{P}) where {P}

--- a/test/ext/special_functions/special_functions.jl
+++ b/test/ext/special_functions/special_functions.jl
@@ -7,7 +7,7 @@ using Mooncake.TestUtils: test_rule
 
 # Rules in this file are only lightly tester, because they are all just @from_rrule rules.
 @testset "special_functions" begin
-    @testset for (perf_flag, f, x...) in vcat(
+    @testset "$perf_flag, $(typeof((f, x...)))" for (perf_flag, f, x...) in vcat(
         map([Float64, Float32]) do P
             return Any[
                 (:stability, airyai, P(0.1)),
@@ -51,7 +51,7 @@ using Mooncake.TestUtils: test_rule
     )
         test_rule(StableRNG(123456), f, x...; perf_flag)
     end
-    @testset for (perf_flag, f, x...) in vcat(
+    @testset "$perf_flag, $(typeof((f, x...)))" for (perf_flag, f, x...) in vcat(
         map([Float64, Float32]) do P
             return Any[
                 (:none, logerf, P(0.3), P(0.5)), # first branch

--- a/test/interpreter/s2s_reverse_mode_ad.jl
+++ b/test/interpreter/s2s_reverse_mode_ad.jl
@@ -106,8 +106,6 @@ end
                 @test length(stmts.fwds) == 2
                 @test stmts.fwds[1][2].stmt isa Expr
                 @test stmts.fwds[2][2].stmt isa ReturnNode
-                @test Meta.isexpr(only(stmts.rvs)[2].stmt, :call)
-                @test only(stmts.rvs)[2].stmt.args[1] == Mooncake.increment_ref!
             end
             @testset "literal" begin
                 stmt_info = make_ad_stmts!(ReturnNode(5.0), line, info)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->

This PR contains some work to ensure that various `Ref`s inserted into the reverse-pass IR always get SROA'd away reliably. This is a PR in the same vein as https://github.com/compintell/Mooncake.jl/pull/430 and https://github.com/compintell/Mooncake.jl/pull/438 -- change how things are implemented to ensure that we're completely insensitive to what type inference / constant prop happens to let us do. The pay off for this kind of work is not receiving hard-to-debug issues in the future / users seeing poor performance, not telling us about it, and giving up on Mooncake entirely.

In short, a variety of Julia functions are inserted into the reverse pass IR at them minute, whose calls _must_ get inlined away if SROA is to successfully remove the `Ref`s. There are various reasons that Julia might not inline these calls away, for example if the argument types are not known statically (meaning that we get dynamic dispatch). This does not just affect functions whose performance we do not care about -- suppose a particular method instance is mostly type stable, but has one or two lines which are type-unstable and are rarely / if ever hit in practice. At present, the presence of these type instabilities will cause the reverse-pass of AD to have additional allocations.

This PR will remove the possibility of this happening by removing these generic functions altogether and inserting the code to handle the references directly into the IR. i.e. you'll see various `getfield(ref, :x)` and `setfield!(ref, :x, val)` calls inserted directly.

todo
- [x] do the same thing for phi node handling
- [x] do the same thing for pi node handling
- [x] remove any code duplication
- [x] remove all newly-redundant code