### PR TITLE
Vargargs Bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.78"
+version = "0.4.79"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -915,9 +915,8 @@ _copy(::Nothing) = nothing
 function _copy(x::P) where {P<:DerivedRule}
     new_captures = _copy(x.fwds_oc.oc.captures)
     new_fwds_oc = replace_captures(x.fwds_oc, new_captures)
-    new_pb_oc_ref = Ref(replace_captures(x.pb.pb_oc[], new_captures))
-    new_pb = typeof(x.pb)(new_pb_oc_ref)
-    return P(new_fwds_oc, new_pb, x.nargs)
+    new_pb_oc_ref = Ref(replace_captures(x.pb_oc_ref[], new_captures))
+    return P(new_fwds_oc, new_pb_oc_ref, x.nargs)
 end
 
 _copy(x::Symbol) = x

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -878,9 +878,7 @@ struct Pullback{Tprimal,Tpb_args,Tpb_ret,isva,nargs}
     pb_oc::Base.RefValue{RuleMC{Tpb_args,Tpb_ret}}
 end
 
-function Pullback(
-    sig, pb_oc::Tpb_oc, isva::Bool, nargs::Int
-) where {A,R,Tpb_oc<:Ref{RuleMC{A,R}}}
+function Pullback(sig, pb_oc::Ref{<:RuleMC{A,R}}, isva::Bool, nargs::Int) where {A,R}
     return Pullback{sig,A,R,isva,nargs}(pb_oc)
 end
 
@@ -890,9 +888,7 @@ function nvargs(pb::Pullback{sig}) where {sig}
     return Val{_isva(pb) ? _nargs(pb) - length(sig.parameters) + 1 : 0}
 end
 
-@inline function (pb::Pullback{sig})(dy) where {sig}
-    return __flatten_varargs(_isva(pb), pb.pb_oc[].oc(dy), nvargs(pb)())
-end
+@inline (pb::Pullback)(dy) = __flatten_varargs(_isva(pb), pb.pb_oc[].oc(dy), nvargs(pb)())
 
 struct DerivedRule{Tprimal,Tfwd_args,Tfwd_ret,Tpb_args,Tpb_ret,isva,Tnargs<:Val}
     fwds_oc::RuleMC{Tfwd_args,Tfwd_ret}

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -874,32 +874,33 @@ const RuleMC{A,R} = MistyClosure{OpaqueClosure{A,R}}
 # between differing varargs conventions.
 #
 
-struct Pullback{Tprimal,Tpb_args,Tpb_ret,isva}
+struct Pullback{Tprimal,Tpb_args,Tpb_ret,isva,nargs}
     pb_oc::Base.RefValue{RuleMC{Tpb_args,Tpb_ret}}
 end
 
-function Pullback(Tprimal, pb_oc::Tpb_oc, isva::Bool) where {A,R,Tpb_oc<:Ref{RuleMC{A,R}}}
-    return Pullback{Tprimal,A,R,isva}(pb_oc)
+function Pullback(Tprimal, pb_oc::Tpb_oc, isva::Bool, nargs::Int) where {A,R,Tpb_oc<:Ref{RuleMC{A,R}}}
+    return Pullback{Tprimal,A,R,isva,nargs}(pb_oc)
 end
 
 _isva(::Pullback{<:Any,<:Any,<:Any,isva}) where {isva} = isva
+_nargs(::Pullback{<:Any,<:Any,<:Any,<:Any,nargs}) where {nargs} = nargs
 
 @inline function (pb::Pullback{sig})(dy) where {sig}
-    return __flatten_varargs(_isva(pb), pb.pb_oc[].oc(dy), nvargs(_isva(pb), sig)())
+    return __flatten_varargs(_isva(pb), pb.pb_oc[].oc(dy), nvargs(_isva(pb), sig, _nargs(pb))())
 end
 
 struct DerivedRule{Tprimal,Tfwd_args,Tfwd_ret,Tpb_args,Tpb_ret,isva,Tnargs<:Val}
     fwds_oc::RuleMC{Tfwd_args,Tfwd_ret}
-    pb::Pullback{Tprimal,Tpb_args,Tpb_ret,isva}
+    pb_oc_ref::Base.RefValue{RuleMC{Tpb_args,Tpb_ret}}
     nargs::Tnargs
 end
 
 _isva(::DerivedRule{A,B,C,D,E,isva}) where {A,B,C,D,E,isva} = isva
 
 function DerivedRule(
-    Tprimal, fwds_oc::RuleMC{FA,FR}, pb::Pullback{<:Any,RA,RR}, isva::Bool, nargs::W
+    Tprimal, fwds_oc::RuleMC{FA,FR}, pb_oc_ref::Base.RefValue{RuleMC{RA,RR}}, isva::Bool, nargs::W
 ) where {FA,FR,RA,RR,W}
-    return DerivedRule{Tprimal,FA,FR,RA,RR,isva,W}(fwds_oc, pb, nargs)
+    return DerivedRule{Tprimal,FA,FR,RA,RR,isva,W}(fwds_oc, pb_oc_ref, nargs)
 end
 
 # Extends functionality defined for debug_mode.
@@ -931,9 +932,10 @@ _copy(x::Type) = x
 
 _copy(x) = copy(x)
 
-@inline function (fwds::DerivedRule{P,Q,S})(args::Vararg{CoDual,N}) where {P,Q,S,N}
+@inline function (fwds::DerivedRule{sig,Q,S,AR,RR,isva})(args::Vararg{CoDual,N}) where {sig,Q,S,AR,RR,isva,N}
     uf_args = __unflatten_codual_varargs(_isva(fwds), args, fwds.nargs)
-    return fwds.fwds_oc.oc(uf_args...)::CoDual, fwds.pb
+    pb = Pullback(sig, fwds.pb_oc_ref, isva, N)
+    return fwds.fwds_oc.oc(uf_args...)::CoDual, pb
 end
 
 """
@@ -1010,7 +1012,7 @@ function rule_type(interp::MooncakeInterpreter{C}, sig_or_mi; debug_mode) where 
     return debug_mode ? DebugRRule{Tderived_rule} : Tderived_rule
 end
 
-nvargs(isva, sig) = Val{isva ? length(sig.parameters[end].parameters) : 0}
+nvargs(isva, sig, nargs) = Val{isva ? nargs - length(sig.parameters) + 1 : 0}
 
 struct MooncakeRuleCompilationError <: Exception
     interp::MooncakeInterpreter
@@ -1125,8 +1127,7 @@ function build_rrule(
                 }
             end
 
-            pb = Pullback(sig, Ref(rvs_oc), dri.isva)
-            raw_rule = DerivedRule(sig, fwd_oc, pb, dri.isva, Val(num_args(dri.info)))
+            raw_rule = DerivedRule(sig, fwd_oc, Ref(rvs_oc), dri.isva, Val(num_args(dri.info)))
             rule = debug_mode ? DebugRRule(raw_rule) : raw_rule
             interp.oc_cache[oc_cache_key] = rule
             return rule

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -604,6 +604,9 @@ end
 
 highly_nested_tuple(x) = ((((x,),), x), x)
 
+# Regression test: https://github.com/compintell/Mooncake.jl/issues/450
+sig_argcount_mismatch(x) = vcat(x[1], x[2:2], x[3:3], x[4:4])
+
 function generate_test_functions()
     return Any[
         (false, :allocs, nothing, const_tester),
@@ -830,6 +833,7 @@ function generate_test_functions()
         (false, :none, nothing, typevar_tester),
         (false, :allocs, nothing, inplace_invoke!, randn(1_024)),
         (false, :allocs, nothing, highly_nested_tuple, 5.0),
+        (false, :none, nothing, sig_argcount_mismatch, ones(4)),
     ]
 end
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Fixes #450 -- this was a systematic problem in the way that we were counting the number of arguments provided to a call site when the call involved a `Vararg`. More explanation to follow later today. The seemingly substantial changes to the plumbing of rule construction are really just needed to change the way in which the number of arguments which are passed to a function are counted (looking at the actual number, rather than looking at the signature, which sometimes doesn't contain sufficient information, as it turns out).

todo:
- [x] explain what was going wrong
- [x] add regression test
- [x] fix failing tests
- [x] tidy up the change in implementation

edit: what was going wrong?

If you have a function of the form
```julia
f(x, y...) = ...
```
you'll see non-splatted calls to it appear in `IRCode` as `f(a, b, c, d)`. For book-keeping-related reasons, we need to know how many elements appear in `y` inside a call to `f` (splatted arguments appear as tuples).

Previously, we were doing this by looking at the signature associated to the `Core.MethodInstance` which appears at a call site. This signature is usually something like
```julia
Tuple{typeof(f), Float64, Float64, Float64, Float64}
```
However, it can also be something like
```julia
Tuple{typeof(f), Float64, Vararg{Float64}}
```
if type inference / the compiler decides that is the best thing to do for some reason. In the first case, everything is fine, but in the second case, I was getting the wrong answer -- plainly, there's not enough information in the second signature to know how many arguments are actually provided at run-time.

The new implementation dispenses with this way of counting arguments, and just encodes in the signature of the `Pullback`, the number of arguments which are _actually_ passed in. If this is known statically, then this will be free -- otherwise it will involve dynamic dispatch, which is what you should expect in this situation.