### PR TITLE
Some Docs Improvements

### DIFF
--- a/docs/src/developer_documentation/misc_internals_notes.md
+++ b/docs/src/developer_documentation/misc_internals_notes.md
@@ -124,3 +124,13 @@ Based on all of the examples that I have seen thus far, it appears to be true th
 2. the function has no side-effects, so can be removed,
 everything will always constant fold nicely.
 This can be achieved by using the `Base.@assume_effects` macro in your method definitions, with the effects `:consistent` and `:removable`.
+
+
+## How Recursion Is Handled
+
+Mooncake handles recursive function calls by delaying code generation for generic function calls until the first time that they are actually run.
+The docstring below contains a thorough explanation:
+
+```@docs
+Mooncake.LazyDerivedRule
+```

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -31,12 +31,24 @@ is_init(t) = true
 val(x::PossiblyUninitTangent) = is_init(x) ? x.tangent : error("Uninitialised")
 val(x) = x
 
+"""
+    Tangent{Tfields<:NamedTuple}
+
+Default type used to represent the tangent of a `struct`. See [`tangent_type`](@ref) for
+more info.
+"""
 struct Tangent{Tfields<:NamedTuple}
     fields::Tfields
 end
 
 Base.:(==)(x::Tangent, y::Tangent) = x.fields == y.fields
 
+"""
+    MutableTangent{Tfields<:NamedTuple}
+
+Default type used to represent the tangent of a `mutable struct`. See [`tangent_type`](@ref)
+for more info.
+"""
 mutable struct MutableTangent{Tfields<:NamedTuple}
     fields::Tfields
     MutableTangent{Tfields}() where {Tfields} = new{Tfields}()


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Converts some discussion points from #389 into actual docs. I realised that the way that `Tangent` / `MutableTangent` work is already fairly well documented in `tangent_type`, so I've added docstrings to both of these types which point towards this documentation.