### PR TITLE
Cstring and Cwstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.88"
+version = "0.4.89"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -297,6 +297,10 @@ tangent_type(::Type{Char}) = NoTangent
 
 tangent_type(::Type{Symbol}) = NoTangent
 
+tangent_type(::Type{Cstring}) = NoTangent
+
+tangent_type(::Type{Cwstring}) = NoTangent
+
 tangent_type(::Type{Module}) = NoTangent
 
 tangent_type(::Type{Nothing}) = NoTangent

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -89,6 +89,10 @@
     ]
         TestUtils.test_tangent_type(primal_type, expected_tangent_type)
     end
+    @testset "type-only tests" begin
+        TestUtils.test_tangent_type(Cstring, NoTangent)
+        TestUtils.test_tangent_type(Cwstring, NoTangent)
+    end
 
     @testset "$(typeof(data))" for (interface_only, data...) in
                                    Mooncake.tangent_test_cases()


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Just adds `NoTangent` tangent types for `Cstring` and `Cwstring`. I've confirmed locally that this ensures that @penelopeysm 's example in #484 successfully errors on the bug from #319 instead of asking you to define `tangent_type` for `Cstring`!