### PR TITLE
Fix can_produce_zero_rdata_from_type performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.90"
+version = "0.4.91"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt.jl
@@ -34,7 +34,7 @@ const CuFloatArray = CuArray{<:IEEEFloat}
 
 # Tell Mooncake.jl how to handle CuArrays.
 
-Mooncake.@tt_effects tangent_type(::Type{P}) where {P<:CuFloatArray} = P
+Mooncake.@foldable tangent_type(::Type{P}) where {P<:CuFloatArray} = P
 function zero_tangent_internal(x::CuFloatArray, stackdict::Any)
     haskey(stackdict, x) && return stackdict[x]::tangent_type(typeof(x))
     t = zero(x)

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -610,7 +610,7 @@ has_definite_fieldcount(P) = P isa DataType && Base.datatype_fieldcount(P) !== n
 Returns whether or not the zero element of the rdata type for primal type `P` can be
 obtained from `P` alone.
 """
-@generated function can_produce_zero_rdata_from_type(::Type{P}) where {P}
+@foldable @generated function can_produce_zero_rdata_from_type(::Type{P}) where {P}
     if isstructtype(P) && has_definite_fieldcount(P)
         can_produces = map(_P -> :(can_produce_zero_rdata_from_type($_P)), fieldtypes(P))
     else
@@ -632,11 +632,11 @@ obtained from `P` alone.
     end
 end
 
-can_produce_zero_rdata_from_type(::Type{<:IEEEFloat}) = true
+@foldable can_produce_zero_rdata_from_type(::Type{<:IEEEFloat}) = true
 
-can_produce_zero_rdata_from_type(::Type{<:Type}) = true
+@foldable can_produce_zero_rdata_from_type(::Type{<:Type}) = true
 
-can_produce_zero_rdata_from_type(::Type{Union{}}) = true
+@foldable can_produce_zero_rdata_from_type(::Type{Union{}}) = true
 
 """
     CannotProduceZeroRDataFromType()

--- a/src/rrules/iddict.jl
+++ b/src/rrules/iddict.jl
@@ -1,6 +1,6 @@
 # We're going to use `IdDict`s to represent tangents for `IdDict`s.
 
-@tt_effects tangent_type(::Type{<:IdDict{K,V}}) where {K,V} = IdDict{K,tangent_type(V)}
+@foldable tangent_type(::Type{<:IdDict{K,V}}) where {K,V} = IdDict{K,tangent_type(V)}
 
 function zero_tangent_internal(d::P, stackdict::Any) where {P<:IdDict}
     T = tangent_type(P)

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -14,7 +14,7 @@
 
 const Maybe{T} = Union{Nothing,T}
 
-@tt_effects tangent_type(::Type{<:Memory{P}}) where {P} = Memory{tangent_type(P)}
+@foldable tangent_type(::Type{<:Memory{P}}) where {P} = Memory{tangent_type(P)}
 
 function zero_tangent_internal(x::Memory{P}, stackdict::Maybe{IdDict}) where {P}
     T = tangent_type(typeof(x))
@@ -279,7 +279,7 @@ end
 
 # Tangent Interface Implementation
 
-@tt_effects tangent_type(::Type{<:MemoryRef{P}}) where {P} = MemoryRef{tangent_type(P)}
+@foldable tangent_type(::Type{<:MemoryRef{P}}) where {P} = MemoryRef{tangent_type(P)}
 
 #=
 Given a new chunk of memory `m`, construct a `MemoryRef` which points to the same relative

--- a/src/rrules/twice_precision.jl
+++ b/src/rrules/twice_precision.jl
@@ -12,7 +12,7 @@
 const TwicePrecisionFloat{P<:IEEEFloat} = TwicePrecision{P}
 const TWP{P} = TwicePrecisionFloat{P}
 
-@tt_effects tangent_type(P::Type{<:TWP}) = P
+@foldable tangent_type(P::Type{<:TWP}) = P
 
 zero_tangent_internal(::TWP{F}, ::StackDict) where {F} = TWP{F}(zero(F), zero(F))
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -829,11 +829,11 @@ function test_rule_and_type_interactions(rng::AbstractRNG, p::P) where {P}
 end
 
 function is_foldable(effects::CC.Effects)
+    tmp = VERSION > v"1.11" ? effects.noub == CC.ALWAYS_TRUE && effects.nortcall : true
     return effects.consistent == CC.ALWAYS_TRUE &&
            effects.effect_free == CC.ALWAYS_TRUE &&
            effects.terminates &&
-           effects.noub == CC.ALWAYS_TRUE &&
-           effects.nortcall
+           tmp
 end
 
 """

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -830,10 +830,10 @@ end
 
 function is_foldable(effects::CC.Effects)
     return effects.consistent == CC.ALWAYS_TRUE &&
-        effects.effect_free == CC.ALWAYS_TRUE &&
-        effects.terminates &&
-        effects.noub == CC.ALWAYS_TRUE &&
-        effects.nortcall
+           effects.effect_free == CC.ALWAYS_TRUE &&
+           effects.terminates &&
+           effects.noub == CC.ALWAYS_TRUE &&
+           effects.nortcall
 end
 
 """

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -828,6 +828,14 @@ function test_rule_and_type_interactions(rng::AbstractRNG, p::P) where {P}
     end
 end
 
+function is_foldable(effects::CC.Effects)
+    return effects.consistent == CC.ALWAYS_TRUE &&
+        effects.effect_free == CC.ALWAYS_TRUE &&
+        effects.terminates &&
+        effects.noub == CC.ALWAYS_TRUE &&
+        effects.nortcall
+end
+
 """
     test_tangent_type(primal_type, expected_tangent_type)
 
@@ -836,11 +844,7 @@ infers / optimises away, and that the effects are as expected.
 """
 function test_tangent_type(primal_type::Type, expected_tangent_type::Type)
     @test tangent_type(primal_type) == expected_tangent_type
-    effects = Base.infer_effects(tangent_type, (Type{expected_tangent_type},))
-    @test effects.consistent == CC.ALWAYS_TRUE
-    @test effects.effect_free == CC.ALWAYS_TRUE
-    @test effects.nothrow
-    @test effects.terminates
+    @test is_foldable(Base.infer_effects(tangent_type, (Type{expected_tangent_type},)))
     return test_opt(Shim(), tangent_type, Tuple{_typeof(primal_type)})
 end
 

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -1,5 +1,4 @@
-using AllocCheck,
-    Aqua,
+using Aqua,
     BenchmarkTools,
     DiffRules,
     JET,
@@ -9,6 +8,8 @@ using AllocCheck,
     StableRNGs,
     Mooncake,
     Test
+
+import AllocCheck # load to enable testing functionality
 
 using ChainRulesCore: ChainRulesCore
 
@@ -72,7 +73,8 @@ using .TestUtils:
     AddressMap,
     populate_address_map_internal,
     populate_address_map,
-    test_tangent
+    test_tangent,
+    check_allocs
 
 using .TestResources:
     TypeStableMutableStruct,

--- a/test/front_matter.jl
+++ b/test/front_matter.jl
@@ -9,7 +9,7 @@ using Aqua,
     Mooncake,
     Test
 
-import AllocCheck # load to enable testing functionality
+using AllocCheck: AllocCheck # load to enable testing functionality
 
 using ChainRulesCore: ChainRulesCore
 

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -1,5 +1,13 @@
 module FwdsRvsDataTestResources
 struct Foo{A} end
+struct Bar{A,B,C}
+    a::A
+    b::B
+    c::C
+end
+struct SV{S<:Tuple, T, L}
+    data::NTuple{L,T}
+end
 end
 
 @testset "fwds_rvs_data" begin
@@ -19,6 +27,7 @@ end
     end
     @testset "zero_rdata_from_type checks" begin
         @test can_produce_zero_rdata_from_type(Vector) == true
+        check_allocs(Mooncake.TestUtils.Shim(), can_produce_zero_rdata_from_type, Vector)
         @test zero_rdata_from_type(Vector) == NoRData()
         @test !can_produce_zero_rdata_from_type(FwdsRvsDataTestResources.Foo)
         @test can_produce_zero_rdata_from_type(Tuple{Float64,Type{Float64}})
@@ -47,6 +56,19 @@ end
         # Check for ambiguity.
         @test Mooncake.can_produce_zero_rdata_from_type(Union{})
         @test Mooncake.zero_rdata_from_type(Union{}) === NoRData()
+
+        # Performance.
+        @testset "$P" for P in Any[
+            Vector{Vector{Vector{Vector{Float64}}}},
+            Vector{Vector{Vector{NTuple{11, Float64}}}},
+            FwdsRvsDataTestResources.Bar{Float64,Float64,Float64},
+            FwdsRvsDataTestResources.Bar{
+                FwdsRvsDataTestResources.SV{Tuple{1},Float64,1},Float64,Float64
+            },
+        ]
+            effects = Base.infer_effects(can_produce_zero_rdata_from_type, Tuple{Type{P}})
+            @test TestUtils.is_foldable(effects)
+        end
     end
     @testset "lazy construction checks" begin
         # Check that lazy construction is in fact lazy for some cases where performance

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -5,7 +5,7 @@ struct Bar{A,B,C}
     b::B
     c::C
 end
-struct SV{S<:Tuple, T, L}
+struct SV{S<:Tuple,T,L}
     data::NTuple{L,T}
 end
 end
@@ -60,7 +60,7 @@ end
         # Performance.
         @testset "$P" for P in Any[
             Vector{Vector{Vector{Vector{Float64}}}},
-            Vector{Vector{Vector{NTuple{11, Float64}}}},
+            Vector{Vector{Vector{NTuple{11,Float64}}}},
             FwdsRvsDataTestResources.Bar{Float64,Float64,Float64},
             FwdsRvsDataTestResources.Bar{
                 FwdsRvsDataTestResources.SV{Tuple{1},Float64,1},Float64,Float64


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Some investigations in TemporalGPs.jl revealed a performance issue with `Mooncake.can_produce_zero_rdata_from_type`. As with `tangent_type` and friends, the most reliable way to get this to have the correct behaviour is to use `Base.@assume_effects :foldable`.

Since this functionality is required across a few functions, I've
1. renamed `@tt_effects` to the much more readable `@foldable`,
2. declared all methods of `Mooncake.can_produce_zero_rdata_from_type` to be `@foldable`, and
3. added regression tests to `Mooncake.can_produce_zero_rdata_from_type`.

