### PR TITLE
Performance of binary method of tangent_type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.92"
+version = "0.4.93"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt.jl
@@ -100,7 +100,7 @@ function Mooncake.__verify_fdata_value(::IdDict{Any,Nothing}, p::CuArray, f::CuA
     end
     return nothing
 end
-tangent_type(::Type{P}, ::Type{NoRData}) where {P<:CuArray} = P
+Mooncake.@foldable tangent_type(::Type{P}, ::Type{NoRData}) where {P<:CuArray} = P
 tangent(p::CuArray, ::NoRData) = p
 
 to_cr_tangent(x::CuFloatArray) = x

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -847,56 +847,56 @@ end
 Given the type of the fdata and rdata, `F` and `R` resp., for some primal type, compute its
 tangent type. This method must be equivalent to `tangent_type(_typeof(primal))`.
 """
-tangent_type(::Type{NoFData}, ::Type{NoRData}) = NoTangent
-tangent_type(::Type{NoFData}, ::Type{R}) where {R<:IEEEFloat} = R
-tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
+@foldable tangent_type(::Type{NoFData}, ::Type{NoRData}) = NoTangent
+@foldable tangent_type(::Type{NoFData}, ::Type{R}) where {R<:IEEEFloat} = R
+@foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Array} = F
 
 # Tuples
-@generated function tangent_type(::Type{F}, ::Type{R}) where {F<:Tuple,R<:Tuple}
+@foldable @generated function tangent_type(::Type{F}, ::Type{R}) where {F<:Tuple,R<:Tuple}
     tt_exprs = map((f, r) -> :(tangent_type($f, $r)), fieldtypes(F), fieldtypes(R))
     return Expr(:curly, :Tuple, tt_exprs...)
 end
-function tangent_type(::Type{NoFData}, ::Type{R}) where {R<:Tuple}
+@foldable function tangent_type(::Type{NoFData}, ::Type{R}) where {R<:Tuple}
     return tangent_type(Tuple{tuple_fill(NoFData, Val(length(R.parameters)))...}, R)
 end
-function tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Tuple}
+@foldable function tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Tuple}
     return tangent_type(F, Tuple{tuple_fill(NoRData, Val(length(F.parameters)))...})
 end
 
 # NamedTuples
-function tangent_type(::Type{F}, ::Type{R}) where {ns,F<:NamedTuple{ns},R<:NamedTuple{ns}}
+@foldable function tangent_type(::Type{F}, ::Type{R}) where {ns,F<:NamedTuple{ns},R<:NamedTuple{ns}}
     return NamedTuple{ns,tangent_type(tuple_type(F), tuple_type(R))}
 end
-function tangent_type(::Type{NoFData}, ::Type{R}) where {ns,R<:NamedTuple{ns}}
+@foldable function tangent_type(::Type{NoFData}, ::Type{R}) where {ns,R<:NamedTuple{ns}}
     return NamedTuple{ns,tangent_type(NoFData, tuple_type(R))}
 end
-function tangent_type(::Type{F}, ::Type{NoRData}) where {ns,F<:NamedTuple{ns}}
+@foldable function tangent_type(::Type{F}, ::Type{NoRData}) where {ns,F<:NamedTuple{ns}}
     return NamedTuple{ns,tangent_type(tuple_type(F), NoRData)}
 end
-tuple_type(::Type{<:NamedTuple{<:Any,T}}) where {T<:Tuple} = T
+@foldable tuple_type(::Type{<:NamedTuple{<:Any,T}}) where {T<:Tuple} = T
 
 # mutable structs
-tangent_type(::Type{F}, ::Type{NoRData}) where {F<:MutableTangent} = F
+@foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:MutableTangent} = F
 
 # structs
-function tangent_type(::Type{F}, ::Type{R}) where {F<:FData,R<:RData}
+@foldable function tangent_type(::Type{F}, ::Type{R}) where {F<:FData,R<:RData}
     return Tangent{tangent_type(fields_type(F), fields_type(R))}
 end
-function tangent_type(::Type{NoFData}, ::Type{R}) where {R<:RData}
+@foldable function tangent_type(::Type{NoFData}, ::Type{R}) where {R<:RData}
     return Tangent{tangent_type(NoFData, fields_type(R))}
 end
-function tangent_type(::Type{F}, ::Type{NoRData}) where {F<:FData}
+@foldable function tangent_type(::Type{F}, ::Type{NoRData}) where {F<:FData}
     return Tangent{tangent_type(fields_type(F), NoRData)}
 end
 
-function tangent_type(
+@foldable function tangent_type(
     ::Type{PossiblyUninitTangent{F}}, ::Type{PossiblyUninitTangent{R}}
 ) where {F,R}
     return PossiblyUninitTangent{tangent_type(F, R)}
 end
 
 # Abstract types.
-tangent_type(::Type{Any}, ::Type{Any}) = Any
+@foldable tangent_type(::Type{Any}, ::Type{Any}) = Any
 
 """
     tangent(f, r)

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -864,7 +864,9 @@ end
 end
 
 # NamedTuples
-@foldable function tangent_type(::Type{F}, ::Type{R}) where {ns,F<:NamedTuple{ns},R<:NamedTuple{ns}}
+@foldable function tangent_type(
+    ::Type{F}, ::Type{R}
+) where {ns,F<:NamedTuple{ns},R<:NamedTuple{ns}}
     return NamedTuple{ns,tangent_type(tuple_type(F), tuple_type(R))}
 end
 @foldable function tangent_type(::Type{NoFData}, ::Type{R}) where {ns,R<:NamedTuple{ns}}

--- a/src/rrules/function_wrappers.jl
+++ b/src/rrules/function_wrappers.jl
@@ -142,7 +142,7 @@ end
 
 fdata_type(T::Type{<:FunctionWrapperTangent}) = T
 rdata_type(::Type{FunctionWrapperTangent}) = NoRData
-tangent_type(F::Type{<:FunctionWrapperTangent}, ::Type{NoRData}) = F
+@foldable tangent_type(F::Type{<:FunctionWrapperTangent}, ::Type{NoRData}) = F
 tangent(f::FunctionWrapperTangent, ::NoRData) = f
 
 function __verify_fdata_value(

--- a/src/rrules/function_wrappers.jl
+++ b/src/rrules/function_wrappers.jl
@@ -22,7 +22,7 @@ function _construct_types(R, A)
     return fwd_oc_type, rvs_oc_type, fwd_sig, rvs_sig
 end
 
-function tangent_type(::Type{FunctionWrapper{R,A}}) where {R,A<:Tuple}
+@foldable function tangent_type(::Type{FunctionWrapper{R,A}}) where {R,A<:Tuple}
     return FunctionWrapperTangent{_construct_types(R, A)[1]}
 end
 

--- a/src/rrules/iddict.jl
+++ b/src/rrules/iddict.jl
@@ -106,7 +106,7 @@ rdata(t::IdDict) = NoRData()
 
 __verify_fdata_value(::IdDict{Any,Nothing}, p::IdDict, f::IdDict) = nothing
 
-tangent_type(::Type{T}, ::Type{NoRData}) where {T<:IdDict} = T
+@foldable tangent_type(::Type{T}, ::Type{NoRData}) where {T<:IdDict} = T
 tangent(f::IdDict, ::NoRData) = f
 
 # All of the rules in here are provided in order to avoid nasty `:ccall`s, and to support

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -351,7 +351,7 @@ fdata_type(::Type{<:MemoryRef{T}}) where {T} = MemoryRef{T}
 
 rdata_type(::Type{<:MemoryRef}) = NoRData
 
-tangent_type(::Type{<:MemoryRef{T}}, ::Type{NoRData}) where {T} = MemoryRef{T}
+@foldable tangent_type(::Type{<:MemoryRef{T}}, ::Type{NoRData}) where {T} = MemoryRef{T}
 
 tangent(f::MemoryRef, ::NoRData) = f
 

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -132,7 +132,7 @@ end
 
 # FData / RData Interface Implementation
 
-tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Memory} = F
+@foldable tangent_type(::Type{F}, ::Type{NoRData}) where {F<:Memory} = F
 
 tangent(f::Memory, ::NoRData) = f
 

--- a/src/rrules/twice_precision.jl
+++ b/src/rrules/twice_precision.jl
@@ -49,7 +49,7 @@ __verify_fdata_value(::IdDict{Any,Nothing}, ::P, ::P) where {P<:TWP} = nothing
 
 _verify_rdata_value(::P, ::P) where {P<:TWP} = nothing
 
-tangent_type(::Type{NoFData}, T::Type{<:TWP}) = T
+@foldable tangent_type(::Type{NoFData}, T::Type{<:TWP}) = T
 
 tangent(::NoFData, t::TWP) = t
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1236,6 +1236,7 @@ function test_fwds_rvs_data(rng::AbstractRNG, p::P) where {P}
 
     # Compute the tangent type associated to `F` and `R`, and check it is equal to `T`.
     @test tangent_type(F, R) == T
+    @test is_foldable(tangent_type, (Type{F}, Type{R}))
 
     # Check that combining f and r yields a tangent of the correct type and value.
     t_combined = Mooncake.tangent(f, r)


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
The binary method of `tangent_type` could sometimes fail to constant-fold properly for tricky examples, in the same way that the unary method previously could.

The solution is to
1. use Mooncake's new `@foldable` macro to just declare that it's foldable, and
2. insert a `@test is_foldable(...)` in the test suite for `test_fwds_rvs_data` to ensure that it always holds.