### PR TITLE
zero_tangent_internal performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.93"
+version = "0.4.94"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/ext/MooncakeCUDAExt.jl
+++ b/ext/MooncakeCUDAExt.jl
@@ -25,7 +25,8 @@ import Mooncake:
     to_cr_tangent,
     increment_and_get_rdata!,
     MaybeCache,
-    IncCache
+    IncCache,
+    StackDict
 
 import Mooncake.TestUtils:
     populate_address_map_internal, AddressMap, __increment_should_allocate
@@ -35,7 +36,7 @@ const CuFloatArray = CuArray{<:IEEEFloat}
 # Tell Mooncake.jl how to handle CuArrays.
 
 Mooncake.@foldable tangent_type(::Type{P}) where {P<:CuFloatArray} = P
-function zero_tangent_internal(x::CuFloatArray, stackdict::Any)
+function zero_tangent_internal(x::CuFloatArray, stackdict::StackDict)
     haskey(stackdict, x) && return stackdict[x]::tangent_type(typeof(x))
     t = zero(x)
     stackdict[x] = t

--- a/src/rrules/function_wrappers.jl
+++ b/src/rrules/function_wrappers.jl
@@ -72,7 +72,7 @@ function _function_wrapper_tangent(R, obj::Tobj, A, obj_tangent) where {Tobj}
 end
 
 function zero_tangent_internal(
-    p::FunctionWrapper{R,A}, stackdict::Union{Nothing,IdDict}
+    p::FunctionWrapper{R,A}, stackdict::StackDict
 ) where {R,A}
 
     # If we've seen this primal before, then we must return that tangent.

--- a/src/rrules/function_wrappers.jl
+++ b/src/rrules/function_wrappers.jl
@@ -71,9 +71,7 @@ function _function_wrapper_tangent(R, obj::Tobj, A, obj_tangent) where {Tobj}
     return t, obj_tangent_ref
 end
 
-function zero_tangent_internal(
-    p::FunctionWrapper{R,A}, stackdict::StackDict
-) where {R,A}
+function zero_tangent_internal(p::FunctionWrapper{R,A}, stackdict::StackDict) where {R,A}
 
     # If we've seen this primal before, then we must return that tangent.
     haskey(stackdict, p) && return stackdict[p]::tangent_type(typeof(p))

--- a/src/rrules/iddict.jl
+++ b/src/rrules/iddict.jl
@@ -2,7 +2,7 @@
 
 @foldable tangent_type(::Type{<:IdDict{K,V}}) where {K,V} = IdDict{K,tangent_type(V)}
 
-function zero_tangent_internal(d::P, stackdict::Any) where {P<:IdDict}
+function zero_tangent_internal(d::P, stackdict::StackDict) where {P<:IdDict}
     T = tangent_type(P)
     if haskey(stackdict, d)
         return stackdict[d]::T

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -16,7 +16,7 @@ const Maybe{T} = Union{Nothing,T}
 
 @foldable tangent_type(::Type{<:Memory{P}}) where {P} = Memory{tangent_type(P)}
 
-function zero_tangent_internal(x::Memory{P}, stackdict::Maybe{IdDict}) where {P}
+function zero_tangent_internal(x::Memory{P}, stackdict::StackDict) where {P}
     T = tangent_type(typeof(x))
 
     # If no stackdict is provided, then the caller promises that there is no need for it.
@@ -150,7 +150,7 @@ end
 # Array -- tangent interface implementation
 #
 
-@inline function zero_tangent_internal(x::Array, stackdict::Maybe{IdDict})
+@inline function zero_tangent_internal(x::Array, stackdict::StackDict)
     T = tangent_type(typeof(x))
 
     # If we already have a tangent for this, just return that.
@@ -298,7 +298,7 @@ function construct_ref(x::MemoryRef, m::Memory)
     return isempty(m) ? memoryref(m) : memoryref(m, Core.memoryrefoffset(x))
 end
 
-function zero_tangent_internal(x::MemoryRef, stackdict::Maybe{IdDict})
+function zero_tangent_internal(x::MemoryRef, stackdict::StackDict)
     return construct_ref(x, zero_tangent_internal(x.mem, stackdict))
 end
 
@@ -529,7 +529,7 @@ function rrule!!(
     ::CoDual{Type{Memory{P}}}, ::CoDual{UndefInitializer}, n::CoDual{Int}
 ) where {P}
     x = Memory{P}(undef, primal(n))
-    dx = zero_tangent_internal(x, nothing)
+    dx = zero_tangent_internal(x, NoCache())
     return CoDual(x, dx), NoPullback((NoRData(), NoRData(), NoRData()))
 end
 

--- a/src/rrules/tasks.jl
+++ b/src/rrules/tasks.jl
@@ -9,7 +9,7 @@ mutable struct TaskTangent end
 
 tangent_type(::Type{Task}) = TaskTangent
 
-function zero_tangent_internal(p::Task, stackdict::Any)
+function zero_tangent_internal(p::Task, stackdict::StackDict)
     if haskey(stackdict, p)
         return stackdict[p]::TaskTangent
     else

--- a/src/rrules/twice_precision.jl
+++ b/src/rrules/twice_precision.jl
@@ -16,7 +16,9 @@ const TWP{P} = TwicePrecisionFloat{P}
 
 zero_tangent_internal(::TWP{F}, ::StackDict) where {F} = TWP{F}(zero(F), zero(F))
 
-function randn_tangent_internal(rng::AbstractRNG, p::TWP{F}, ::Union{Nothing, IdDict}) where {F}
+function randn_tangent_internal(
+    rng::AbstractRNG, p::TWP{F}, ::Union{Nothing,IdDict}
+) where {F}
     return TWP{F}(randn(rng, F), randn(rng, F))
 end
 

--- a/src/rrules/twice_precision.jl
+++ b/src/rrules/twice_precision.jl
@@ -16,7 +16,7 @@ const TWP{P} = TwicePrecisionFloat{P}
 
 zero_tangent_internal(::TWP{F}, ::StackDict) where {F} = TWP{F}(zero(F), zero(F))
 
-function randn_tangent_internal(rng::AbstractRNG, p::TWP{F}, ::StackDict) where {F}
+function randn_tangent_internal(rng::AbstractRNG, p::TWP{F}, ::Union{Nothing, IdDict}) where {F}
     return TWP{F}(randn(rng, F), randn(rng, F))
 end
 
@@ -29,7 +29,7 @@ end
 
 increment_internal!!(::IncCache, t::T, s::T) where {T<:TWP} = t + s
 
-set_to_zero_internal!!(::IncCache, t::TWP) = zero_tangent_internal(t, nothing)
+set_to_zero_internal!!(::IncCache, t::TWP) = zero_tangent_internal(t, NoCache())
 
 _add_to_primal_internal(::MaybeCache, p::P, t::P, ::Bool) where {P<:TWP} = p + t
 

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -464,7 +464,9 @@ Internally, `zero_tangent` calls `zero_tangent_internal`, which handles differen
 handles both circular references and aliasing correctly.
 """
 zero_tangent(x)
-zero_tangent(x::P) where {P} = zero_tangent_internal(x, isbitstype(P) ? NoCache() : IdDict())
+function zero_tangent(x::P) where {P}
+    return zero_tangent_internal(x, isbitstype(P) ? NoCache() : IdDict())
+end
 
 const StackDict = Union{NoCache,IdDict}
 

--- a/src/test_resources.jl
+++ b/src/test_resources.jl
@@ -123,6 +123,40 @@ struct StructNoRvs
     x::Vector{Float64}
 end
 
+struct FiveFields{A,B,C,D,E}
+    a::A
+    b::B
+    c::C
+    d::D
+    e::E
+end
+
+struct FourFields{A,B,C,D}
+    a::A
+    b::B
+    c::C
+    d::D
+end
+
+struct OneField{A}
+    a::A
+end
+
+function build_big_isbits_struct()
+    return FourFields(
+        FiveFields(
+            FourFields(OneField(5.0), OneField(5.0), OneField(3), OneField(nothing)),
+            OneField(4),
+            OneField(3.0),
+            OneField(nothing),
+            OneField(false),
+        ),
+        OneField(5.0),
+        OneField(nothing),
+        OneField(4),
+    )
+end
+
 #
 # generate test cases for circular references
 #

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -1033,7 +1033,9 @@ function test_tangent_performance(rng::AbstractRNG, p::P) where {P}
     # Check there are no allocations when there ought not to be.
     if !__tangent_generation_should_allocate(P)
         test_opt(Tuple{typeof(zero_tangent),P})
+        check_allocs(Mooncake.zero_tangent, p)
         test_opt(Tuple{typeof(randn_tangent),Xoshiro,P})
+        check_allocs(Mooncake.randn_tangent, rng, p)
     end
 
     # `increment!!` should always infer.


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Inference / constant propagation in zero_tangent_internal will currently occasionally fall over, for all of the usual reasons. It's necessary to use a generated function to iterate over the fields of the type.

While here, I'm updating the requirements imposed on `zero_tangent_internal`'s stackdict -- in particular insisting that it's of the same type as that used for various other related functions (`set_to_zero!!` etc).

todo:
- [x] get CI passing
- [x] figure out how to produce a failing test which doesn't involve TemporalGPs.jl.
 
edit: just waiting for CI to pass, then I'll merge + release.