### PR TITLE
Improve Stack Performance v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.98"
+version = "0.4.99"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -27,7 +27,7 @@ end
 
 @inline function Base.pop!(x::Stack)
     position = x.position
-    val = x.memory[position]
+    val = @inbounds x.memory[position]
     x.position = position - 1
     return val
 end


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
After digging around a bit in #499 , it looks like most of the performance gains that weren't associated with a pathologically-unsafe use of `unsafe_store!` were associated to disabling bounds checking when popping elements from `Stack`s:
```julia
julia> using BenchmarkTools, Mooncake

julia> function push_stack(s::Mooncake.Stack{T}) where {T}
           @inbounds for _ in 1:10_000_000
               push!(s, T(false))
           end
           return nothing
       end
push_stack (generic function with 1 method)

julia> function pop_stack(s::Mooncake.Stack{T}) where {T}
           t = zero(T)
           @inbounds for _ in 1:1_000
               t = pop!(s)
           end
           return t
       end
pop_stack (generic function with 1 method)

julia> @benchmark (push_stack($s); pop_stack($s)) # with bounds checking disabled
BenchmarkTools.Trial: 10000 samples with 10 evaluations per sample.
 Range (min … max):  1.942 μs …  11.854 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.967 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.019 μs ± 319.103 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▆█▆▁                                                        ▁
  ████▄▆▇▆▅▄▂▄▃▄▃▄▄▃▂▃▅█▆▇█▇▇▆▆▅▄▄▄▄▄▂▃▄▂▄▅▄▅▆▆▅▅▄▅▅▃▃▆▆▄▆▅▄▃ █
  1.94 μs      Histogram: log(frequency) by time      2.97 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark (push_stack($s); pop_stack($s)) # bounds checking enabled
BenchmarkTools.Trial: 10000 samples with 9 evaluations per sample.
 Range (min … max):  2.407 μs …  12.921 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.444 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.490 μs ± 305.490 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▂▇█▅                                                        ▁
  ████▇▃▅▅▆▃▃▄▄▃▅▃▃▄▃▃▂▄▇▇▆▇█▆▇▆▅▆▆▅▄▄▄▃▃▃▄▃▃▂▅▃▄▅▄▄▅▄▄▅▃▅▅▆▅ █
  2.41 μs      Histogram: log(frequency) by time      3.47 μs <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
This is a one-liner, so it feels like a reasonable change to me.
