### PR TITLE
Fix unsafe_copyto with memoryref

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.99"
+version = "0.4.100"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/memory.jl
+++ b/src/rrules/memory.jl
@@ -265,7 +265,9 @@ function rrule!!(
         # Increment gradients.
         @inbounds for i in 1:n
             src_ref = memoryref(src.dx, i)
-            src_ref[] = increment!!(src_ref[], memoryref(tmp, i)[])
+            if isassigned(src_ref)
+                src_ref[] = increment!!(src_ref[], memoryref(tmp, i)[])
+            end
         end
 
         return ntuple(_ -> NoRData(), 4)
@@ -799,6 +801,15 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:memory})
             unsafe_copyto!,
             [randn(rng, 10), randn(rng, 5)].ref,
             [randn(rng, 10), randn(rng, 3)].ref,
+            2,
+        ),
+        (
+            false,
+            :none,
+            nothing,
+            unsafe_copyto!,
+            memoryref(fill!(Memory{Any}(undef, 3), 4.0), 1),
+            memoryref(Memory{Any}(undef, 2)),
             2,
         ),
 


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Resolves #504 .