### PR TITLE
GC between benchmarks

### DIFF
--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -184,7 +184,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
             # Benchmark primal.
             @info "Primal"
             primals = map(x -> x isa CoDual ? primal(x) : x, args)
-            GC.gc(true)
+            include_other_frameworks && GC.gc(true)
             suite["primal"] = Chairmarks.benchmark(
                 () -> primals,
                 primals -> (primals[1], _deepcopy(primals[2:end])),
@@ -198,7 +198,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
             rule = Mooncake.build_rrule(args...)
             coduals = map(x -> x isa CoDual ? x : zero_codual(x), args)
             to_benchmark(rule, coduals...)
-            GC.gc(true)
+            include_other_frameworks && GC.gc(true)
             suite["mooncake"] = Chairmarks.benchmark(
                 () -> (rule, coduals),
                 identity,

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -222,10 +222,10 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
 
                 if should_run_benchmark(Val(:reverse_diff), args...)
                     @info "ReverseDiff"
-                    GC.gc(true)
                     tape = ReverseDiff.GradientTape(primals[1], primals[2:end])
                     compiled_tape = ReverseDiff.compile(tape)
                     result = map(x -> randn(size(x)), primals[2:end])
+                    GC.gc(true)
                     suite["rd"] = @be(
                         _,
                         _,
@@ -237,9 +237,9 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
 
                 if should_run_benchmark(Val(:enzyme), args...)
                     @info "Enzyme"
-                    GC.gc(true)
                     _rand_similiar(x) = x isa Real ? randn() : randn(size(x))
                     dup_args = map(x -> Duplicated(x, _rand_similiar(x)), primals[2:end])
+                    GC.gc(true)
                     suite["enzyme"] = @be(
                         _,
                         _,

--- a/bench/run_benchmarks.jl
+++ b/bench/run_benchmarks.jl
@@ -184,6 +184,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
             # Benchmark primal.
             @info "Primal"
             primals = map(x -> x isa CoDual ? primal(x) : x, args)
+            GC.gc(true)
             suite["primal"] = Chairmarks.benchmark(
                 () -> primals,
                 primals -> (primals[1], _deepcopy(primals[2:end])),
@@ -197,6 +198,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
             rule = Mooncake.build_rrule(args...)
             coduals = map(x -> x isa CoDual ? x : zero_codual(x), args)
             to_benchmark(rule, coduals...)
+            GC.gc(true)
             suite["mooncake"] = Chairmarks.benchmark(
                 () -> (rule, coduals),
                 identity,
@@ -208,6 +210,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
             if include_other_frameworks
                 if should_run_benchmark(Val(:zygote), args...)
                     @info "Zygote"
+                    GC.gc(true)
                     suite["zygote"] = @be(
                         _,
                         _,
@@ -219,6 +222,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
 
                 if should_run_benchmark(Val(:reverse_diff), args...)
                     @info "ReverseDiff"
+                    GC.gc(true)
                     tape = ReverseDiff.GradientTape(primals[1], primals[2:end])
                     compiled_tape = ReverseDiff.compile(tape)
                     result = map(x -> randn(size(x)), primals[2:end])
@@ -233,6 +237,7 @@ function benchmark_rules!!(test_case_data, default_ratios, include_other_framewo
 
                 if should_run_benchmark(Val(:enzyme), args...)
                     @info "Enzyme"
+                    GC.gc(true)
                     _rand_similiar(x) = x isa Real ? randn() : randn(size(x))
                     dup_args = map(x -> Duplicated(x, _rand_similiar(x)), primals[2:end])
                     suite["enzyme"] = @be(


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
I think it's possible that the variance we often see in benchmarks is because we're not properly GC-ing between benchmarks. This PR hopefully addresses this problem, although it's obviously rather hard to know whether this has worked from a single run.