### PR TITLE
Fix unsafe_copyto on 1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,10 +48,10 @@ jobs:
           - x64
         include:
           - test_group: 'basic'
-            version: '1.10'
+            version: 'lts'
             arch: x86
           - test_group: 'rrules/array_legacy'
-            version: '1.10'
+            version: 'lts'
             arch: x64
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,9 @@ jobs:
           - test_group: 'basic'
             version: '1.10'
             arch: x86
+          - test_group: 'rrules/array_legacy'
+            version: '1.10'
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.103"
+version = "0.4.104"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/array_legacy.jl
+++ b/src/rrules/array_legacy.jl
@@ -262,7 +262,11 @@ function rrule!!(
 
         # Increment dsrc.
         src_idx = _soffs:(_soffs + _n - 1)
-        dsrc[src_idx] .= increment!!.(view(dsrc, src_idx), view(ddest, dest_idx))
+        @inbounds for (s, d) in zip(src_idx, dest_idx)
+            if isassigned(dsrc, s)
+                dsrc[s] = increment!!(dsrc[s], ddest[d])
+            end
+        end
 
         # Restore initial state.
         @inbounds for n in eachindex(dest_copy)
@@ -449,6 +453,17 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:array_legacy}
             3,
         ),
         (
+            false,
+            :none,
+            nothing,
+            unsafe_copyto!,
+            fill!(Vector{Any}(undef, 3), 4.0),
+            1,
+            Vector{Any}(undef, 2),
+            1,
+            2,
+        ),
+        (
             true,
             :none,
             nothing,
@@ -486,7 +501,6 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:array_legacy}
             randn(4),
             1,
         ),
-        (false, :stability, nothing, Base.arrayset, false, _a, randn(4), 1),
         (
             false,
             :stability,

--- a/test/rrules/array_legacy.jl
+++ b/test/rrules/array_legacy.jl
@@ -1,0 +1,3 @@
+@testset "array_legacy" begin
+    TestUtils.run_rrule!!_test_cases(StableRNG, Val(:array_legacy))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,8 @@ include("front_matter.jl")
         include("config.jl")
         include("developer_tools.jl")
         include("test_utils.jl")
+    elseif test_group == "rrules/array_legacy"
+        include(joinpath("rrules", "array_legacy.jl"))
     elseif test_group == "rrules/avoiding_non_differentiable_code"
         include(joinpath("rrules", "avoiding_non_differentiable_code.jl"))
     elseif test_group == "rrules/blas"


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
#513 highlights that #505 only addressed `Memory` / `MemoryRef`s, and therefore didn't address an equivalent issue on 1.10. This PR just fixes that.

It also ensures that we run the tests for the legacy rules. Concerningly, we were not previously doing so...