### PR TITLE
Minor RNG Improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.105"
+version = "0.4.106"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/rrules/random.jl
+++ b/src/rrules/random.jl
@@ -1,5 +1,5 @@
 # Contains a ccall, which must be avoided.
-@zero_adjoint MinimalCtx Tuple{Type{<:MersenneTwister},Any}
+@zero_adjoint MinimalCtx Tuple{Type{MersenneTwister},Any}
 
 const KnownRNGs = Union{MersenneTwister,RandomDevice,TaskLocalRNG,Xoshiro}
 @zero_adjoint MinimalCtx Tuple{typeof(randn),KnownRNGs}

--- a/src/rrules/random.jl
+++ b/src/rrules/random.jl
@@ -1,5 +1,5 @@
+# Contains a ccall, which must be avoided.
 @zero_adjoint MinimalCtx Tuple{Type{<:MersenneTwister},Any}
-@zero_adjoint MinimalCtx Tuple{Type{<:Xoshiro},Union{Integer,AbstractString}}
 
 const KnownRNGs = Union{MersenneTwister,RandomDevice,TaskLocalRNG,Xoshiro}
 @zero_adjoint MinimalCtx Tuple{typeof(randn),KnownRNGs}
@@ -34,7 +34,6 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:random})
         # Random number generator construction.
         # There are some undefined fields at construction, so we cannot run equality tests.
         (true, :none, nothing, MersenneTwister, 123),
-        (true, :none, nothing, Xoshiro, 123),
 
         # Random number generation.
         map_prod([randn, randexp], all_rngs) do (f, rng)
@@ -65,7 +64,7 @@ function generate_derived_rrule!!_test_cases(rng_ctor, ::Val{:random})
 
         # RNG construction.
         (false, :none, nothing, x -> randn(MersenneTwister(x)), 123),
-        (false, :none, nothing, x -> randn(Xoshiro(x)), 123),
+        (false, :none, nothing, Xoshiro, 123),
         (false, :none, nothing, x -> randn(Random.seed!(TaskLocalRNG(), x)), 123),
 
         # It is not possible to make the numbers produced by a `RandomDevice` be


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
The constructor for MersenneTwister appears to have a `ccall` in it, meaning that we couldn't differentiate through its construction. This PR introduces a patch for it. It also adds tests to make sure that all of the standard random number generators can be correctly constructed.