### PR TITLE
Rule for throw

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Mooncake"
 uuid = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 authors = ["Will Tebbutt, Hong Ge, and contributors"]
-version = "0.4.109"
+version = "0.4.110"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/codual.jl
+++ b/src/codual.jl
@@ -32,7 +32,7 @@ Equivalent to `CoDual(x, uninit_tangent(x))`.
 uninit_codual(x) = CoDual(x, uninit_tangent(x))
 
 function _codual_internal(::Type{P}, f::F, extractor::E) where {P,F,E}
-    P == Union{} && return CoDual
+    P == Union{} && return Union{}
     P == DataType && return CoDual
     P isa Union && return Union{f(P.a),f(P.b)}
 

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -155,7 +155,7 @@ fdata_type(T)
 
 fdata_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))
 
-fdata_type(::Type{Union{}}) = Union{}
+@foldable fdata_type(::Type{Union{}}) = Union{}
 
 fdata_type(::Type{T}) where {T<:IEEEFloat} = NoFData
 
@@ -421,7 +421,7 @@ rdata_type(T)
 
 rdata_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))
 
-rdata_type(::Type{Union{}}) = Union{}
+@foldable rdata_type(::Type{Union{}}) = Union{}
 
 rdata_type(::Type{T}) where {T<:IEEEFloat} = T
 

--- a/src/fwds_rvs_data.jl
+++ b/src/fwds_rvs_data.jl
@@ -155,6 +155,8 @@ fdata_type(T)
 
 fdata_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))
 
+fdata_type(::Type{Union{}}) = Union{}
+
 fdata_type(::Type{T}) where {T<:IEEEFloat} = NoFData
 
 function fdata_type(::Type{PossiblyUninitTangent{T}}) where {T}
@@ -418,6 +420,8 @@ See extended help in [`fdata_type`](@ref) docstring.
 rdata_type(T)
 
 rdata_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))
+
+rdata_type(::Type{Union{}}) = Union{}
 
 rdata_type(::Type{T}) where {T<:IEEEFloat} = T
 

--- a/src/interpreter/s2s_reverse_mode_ad.jl
+++ b/src/interpreter/s2s_reverse_mode_ad.jl
@@ -1374,10 +1374,6 @@ Produce the IR associated to the `OpaqueClosure` which runs most of the pullback
 function pullback_ir(
     ir::BBCode, Tret, ad_stmts_blocks::ADStmts, pb_comms_insts, info::ADInfo, Tshared_data
 )
-
-    # Compute the argument types associated to the reverse-pass.
-    arg_types = vcat(Tshared_data, rdata_type(tangent_type(Tret)))
-
     # Compute the blocks which return in the primal.
     primal_exit_blocks_inds = findall(is_reachable_return_node ∘ terminator, ir.blocks)
 
@@ -1390,12 +1386,15 @@ function pullback_ir(
     # won't succeed on the forwards-pass. As such, the reverse-pass can just be a no-op.
     if isempty(primal_exit_blocks_inds)
         blocks = [BBlock(ID(), [(ID(), new_inst(ReturnNode(nothing)))])]
-        return BBCode(blocks, arg_types, ir.sptypes, ir.linetable, ir.meta)
+        return BBCode(blocks, Any[Any], ir.sptypes, ir.linetable, ir.meta)
     end
 
     #
     # Standard path pullback generation -- applies to 99% of primals:
     #
+
+    # Compute the argument types associated to the reverse-pass.
+    arg_types = vcat(Tshared_data, rdata_type(tangent_type(Tret)))
 
     # Create entry block which:
     # 1. extracts items from shared data to the correct IDs,
@@ -1846,7 +1845,8 @@ function rule_type(interp::MooncakeInterpreter{C}, sig_or_mi; debug_mode) where 
     sig = Tuple{arg_types...}
     fwd_args_type = Tuple{map(fcodual_type, arg_types)...}
     fwd_return_type = forwards_ret_type(ir)
-    pb_args_type = Tuple{rdata_type(tangent_type(Treturn))}
+    Trdata_return = rdata_type(tangent_type(Treturn))
+    pb_args_type = Trdata_return === Union{} ? Union{} : Tuple{Trdata_return}
     pb_return_type = pullback_ret_type(ir)
     nargs = Val{length(ir.argtypes)}
 

--- a/src/rrules/builtins.jl
+++ b/src/rrules/builtins.jl
@@ -687,7 +687,8 @@ function rrule!!(::CoDual{typeof(setfield!)}, value::CoDual, name::CoDual, x::Co
 end
 
 # swapfield!
-# throw
+
+rrule!!(::CoDual{typeof(throw)}, args::CoDual...) = throw(map(primal, args)...)
 
 struct TuplePullback{N} end
 
@@ -1009,7 +1010,6 @@ function generate_hand_written_rrule!!_test_cases(rng_ctor, ::Val{:builtins})
         (false, :none, _range, setfield!, NonDifferentiableFoo(5, false), 1, 4),
         (false, :none, _range, setfield!, NonDifferentiableFoo(5, true), 2, false),
         # swapfield! -- NEEDS IMPLEMENTING AND TESTING
-        # throw -- NEEDS IMPLEMENTING AND TESTING
         (false, :stability_and_allocs, nothing, tuple, 5.0, 4.0),
         (false, :stability_and_allocs, nothing, tuple, randn(5), 5.0),
         (false, :stability_and_allocs, nothing, tuple, randn(5), randn(4)),

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -276,7 +276,7 @@ tangent_type(T)
 tangent_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))
 
 # The "Bottom" type.
-tangent_type(::Type{Union{}}) = Union{}
+@foldable tangent_type(::Type{Union{}}) = Union{}
 
 # This is essential for DataType, as the recursive definition always recurses infinitely,
 # because one of the fieldtypes is itself always a DataType. In particular, we'll always

--- a/src/tangents.jl
+++ b/src/tangents.jl
@@ -276,7 +276,7 @@ tangent_type(T)
 tangent_type(x) = throw(error("$x is not a type. Perhaps you meant typeof(x)?"))
 
 # The "Bottom" type.
-tangent_type(::Type{Union{}}) = NoTangent
+tangent_type(::Type{Union{}}) = Union{}
 
 # This is essential for DataType, as the recursive definition always recurses infinitely,
 # because one of the fieldtypes is itself always a DataType. In particular, we'll always

--- a/test/fwds_rvs_data.jl
+++ b/test/fwds_rvs_data.jl
@@ -12,6 +12,7 @@ end
 
 @testset "fwds_rvs_data" begin
     @testset "fdata_type / rdata_type($P)" for (P, F, R) in Any[
+        (Union{}, Union{}, Union{}),
         (
             Tuple{Any,Vector{Float64}},
             Tuple{Any,Vector{Float64}},

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -1,3 +1,5 @@
+foo_throws(e) = throw(e)
+
 @testset "builtins" begin
     @test_throws(
         ErrorException,
@@ -54,28 +56,27 @@
         )
     end
 
-    # @testset "throw" begin
-    #     # Throw primitive continues to throw the exception it is meant to.
-    #     @test_throws(
-    #         ArgumentError,
-    #         Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
-    #     )
-    #     @test_throws(
-    #         AssertionError,
-    #         Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
-    #     )
+    @testset "throw" begin
+        # Throw primitive continues to throw the exception it is meant to.
+        @test_throws(
+            ArgumentError,
+            Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
+        )
+        @test_throws(
+            AssertionError,
+            Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
+        )
 
-    #     # Derived rule throws the correct exception.
-    #     foo_throws(e) = throw(e)
-    #     rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
-    #     @test_throws(
-    #         ArgumentError,
-    #         rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
-    #     )
-    #     rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
-    #     @test_throws(
-    #         AssertionError,
-    #         rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
-    #     )
-    # end
+        # Derived rule throws the correct exception.
+        rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
+        @test_throws(
+            ArgumentError,
+            rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
+        )
+        rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
+        @test_throws(
+            AssertionError,
+            rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
+        )
+    end
 end

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -1,11 +1,11 @@
 @testset "builtins" begin
     @test_throws(
         ErrorException,
-        Mooncake.rrule!!(zero_fcodual(IntrinsicsWrappers.add_ptr), 5.0, 4.0),
+        Mooncake.rrule!!(CoDual(IntrinsicsWrappers.add_ptr, NoTangent()), 5.0, 4.0),
     )
     @test_throws(
         ErrorException,
-        Mooncake.rrule!!(zero_fcodual(IntrinsicsWrappers.sub_ptr), 5.0, 4.0),
+        Mooncake.rrule!!(CoDual(IntrinsicsWrappers.sub_ptr, NoTangent()), 5.0, 4.0),
     )
 
     @testset "_apply_iterate_equivalent with $(typeof(args))" for args in Any[

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -54,26 +54,28 @@
         )
     end
 
-    # Throw primitive continues to throw the exception it is meant to.
-    @test_throws(
-        ArgumentError,
-        Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
-    )
-    @test_throws(
-        AssertionError,
-        Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
-    )
+    @testset "throw" begin
+        # Throw primitive continues to throw the exception it is meant to.
+        @test_throws(
+            ArgumentError,
+            Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
+        )
+        @test_throws(
+            AssertionError,
+            Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
+        )
 
-    # Derived rule throws the correct exception.
-    foo_throws(e) = throw(e)
-    rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
-    @test_throws(
-        ArgumentError,
-        rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
-    )
-    rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
-    @test_throws(
-        AssertionError,
-        rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
-    )
+        # Derived rule throws the correct exception.
+        foo_throws(e) = throw(e)
+        rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
+        @test_throws(
+            ArgumentError,
+            rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
+        )
+        rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
+        @test_throws(
+            AssertionError,
+            rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
+        )
+    end
 end

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -54,28 +54,28 @@
         )
     end
 
-    @testset "throw" begin
-        # Throw primitive continues to throw the exception it is meant to.
-        @test_throws(
-            ArgumentError,
-            Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
-        )
-        @test_throws(
-            AssertionError,
-            Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
-        )
+    # @testset "throw" begin
+    #     # Throw primitive continues to throw the exception it is meant to.
+    #     @test_throws(
+    #         ArgumentError,
+    #         Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
+    #     )
+    #     @test_throws(
+    #         AssertionError,
+    #         Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
+    #     )
 
-        # Derived rule throws the correct exception.
-        foo_throws(e) = throw(e)
-        rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
-        @test_throws(
-            ArgumentError,
-            rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
-        )
-        rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
-        @test_throws(
-            AssertionError,
-            rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
-        )
-    end
+    #     # Derived rule throws the correct exception.
+    #     foo_throws(e) = throw(e)
+    #     rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
+    #     @test_throws(
+    #         ArgumentError,
+    #         rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
+    #     )
+    #     rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
+    #     @test_throws(
+    #         AssertionError,
+    #         rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
+    #     )
+    # end
 end

--- a/test/rrules/builtins.jl
+++ b/test/rrules/builtins.jl
@@ -1,12 +1,11 @@
 @testset "builtins" begin
     @test_throws(
         ErrorException,
-        Mooncake.rrule!!(CoDual(IntrinsicsWrappers.add_ptr, NoTangent()), 5.0, 4.0),
+        Mooncake.rrule!!(zero_fcodual(IntrinsicsWrappers.add_ptr), 5.0, 4.0),
     )
-
     @test_throws(
         ErrorException,
-        Mooncake.rrule!!(CoDual(IntrinsicsWrappers.sub_ptr, NoTangent()), 5.0, 4.0),
+        Mooncake.rrule!!(zero_fcodual(IntrinsicsWrappers.sub_ptr), 5.0, 4.0),
     )
 
     @testset "_apply_iterate_equivalent with $(typeof(args))" for args in Any[
@@ -54,4 +53,27 @@
             rrule!!(zero_fcodual(bitcast), zero_fcodual(Float64), zero_fcodual(5))
         )
     end
+
+    # Throw primitive continues to throw the exception it is meant to.
+    @test_throws(
+        ArgumentError,
+        Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(ArgumentError("hello")))
+    )
+    @test_throws(
+        AssertionError,
+        Mooncake.rrule!!(zero_fcodual(throw), zero_fcodual(AssertionError("hello")))
+    )
+
+    # Derived rule throws the correct exception.
+    foo_throws(e) = throw(e)
+    rule_arg = Mooncake.build_rrule(Tuple{typeof(foo_throws),ArgumentError})
+    @test_throws(
+        ArgumentError,
+        rule_arg(zero_fcodual(foo_throws), zero_fcodual(ArgumentError("hello")))
+    )
+    rule_assert = Mooncake.build_rrule(Tuple{typeof(foo_throws),AssertionError})
+    @test_throws(
+        AssertionError,
+        rule_assert(zero_fcodual(foo_throws), zero_fcodual(AssertionError("hmmm")))
+    )
 end

--- a/test/tangents.jl
+++ b/test/tangents.jl
@@ -1,6 +1,11 @@
 @testset "tangents" begin
     @testset "$(tangent_type(primal_type))" for (primal_type, expected_tangent_type) in Any[
 
+        ## Misc. Specific Types
+        (Cstring, NoTangent),
+        (Cwstring, NoTangent),
+        (Union{}, Union{}),
+
         ## Tuples
 
         # Unions of Tuples.
@@ -88,10 +93,6 @@
         ),
     ]
         TestUtils.test_tangent_type(primal_type, expected_tangent_type)
-    end
-    @testset "type-only tests" begin
-        TestUtils.test_tangent_type(Cstring, NoTangent)
-        TestUtils.test_tangent_type(Cwstring, NoTangent)
     end
 
     @testset "$(typeof(data))" for (interface_only, data...) in


### PR DESCRIPTION
<!--
    Thank you for opening a pull request to Mooncake.jl!
    Please note that this project operates the following policy: any time a PR is merged
    which modifies code in the src directory, a release must be made.

    Consequently, if your PR modifies something in src, please follow semver to figure out
    how you should modify the version number in Project.toml. If it's unclear to you how the
    version number should be modified, please open your PR without modifying it, and ask for
    assistance -- one of the maintainers will be happy to help figure out what the new
    version number ought to be.
-->
Adds an `rrule!!` for throw, which has the behaviour that it just throws the original exception. I might tweak this to add a little bit more context at a later date, because currently it's not currently quite as informative as it might be.

Addresses part of #534 